### PR TITLE
Add Streamlit-based Hornby layout planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # OOplanner
 Design OO gauge layout based on user selectable board shape and size
 The user designs the board and the code returns possible layout options based on user selectable variables such as maximising track density, maximising straights, loops etc
+
+## Running the planner
+
+1. Install the dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Launch the Streamlit interface:
+
+   ```bash
+   streamlit run app.py
+   ```
+
+3. Open the provided local URL in your browser to explore layout suggestions based on your board and priorities.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,158 @@
+from typing import List, Tuple
+
+import matplotlib.pyplot as plt
+import pandas as pd
+import streamlit as st
+
+from planner import (
+    BoardSpecification,
+    LayoutGenerator,
+    LayoutPlan,
+    describe_board,
+    default_templates,
+    draw_geometry,
+)
+
+
+st.set_page_config(page_title="Hornby OO Layout Planner", layout="wide")
+st.title("Hornby OO Gauge Layout Planner")
+st.write(
+    """Design OO gauge train set plans by choosing a baseboard size and the features you would like in your layout.\n"
+    "The planner uses real-world Hornby set-track dimensions to recommend track plans that fit within your available space."""
+)
+
+
+@st.cache_resource
+def get_generator() -> LayoutGenerator:
+    return LayoutGenerator(default_templates())
+
+
+def _board_controls() -> BoardSpecification:
+    st.sidebar.header("Board")
+    shape = st.sidebar.selectbox("Board shape", ["Rectangle", "L-Shape", "Custom polygon"], index=0)
+
+    if shape == "Rectangle":
+        width = st.sidebar.number_input("Width (mm)", min_value=600.0, value=1800.0, step=50.0)
+        height = st.sidebar.number_input("Depth (mm)", min_value=450.0, value=1200.0, step=50.0)
+        return BoardSpecification(shape="rectangle", width=width, height=height)
+
+    if shape == "L-Shape":
+        long_leg = st.sidebar.number_input("Long leg length (mm)", min_value=1000.0, value=2400.0, step=50.0)
+        short_leg = st.sidebar.number_input("Short leg length (mm)", min_value=800.0, value=1500.0, step=50.0)
+        width = st.sidebar.number_input("Overall width (mm)", min_value=600.0, value=900.0, step=25.0)
+        polygon = [(0.0, 0.0), (long_leg, 0.0), (long_leg, width), (width, width), (width, short_leg), (0.0, short_leg)]
+        return BoardSpecification(shape="l-shape", width=long_leg, height=short_leg, polygon=polygon)
+
+    st.sidebar.markdown("Enter the corner points of your board outline in millimetres.")
+    default_points: List[Tuple[float, float]] = [(0.0, 0.0), (2400.0, 0.0), (2400.0, 1200.0), (0.0, 1200.0)]
+    data = st.sidebar.data_editor(
+        pd.DataFrame(default_points, columns=["x", "y"]),
+        num_rows="dynamic",
+        key="custom_polygon",
+    )
+    polygon = list(data.itertuples(index=False, name=None))
+    return BoardSpecification(
+        shape="custom",
+        width=max(p[0] for p in polygon) if polygon else 0.0,
+        height=max(p[1] for p in polygon) if polygon else 0.0,
+        polygon=polygon,
+    )
+
+
+def _objective_controls() -> Tuple[List[str], List[float]]:
+    st.sidebar.header("Layout priorities")
+    objectives = st.sidebar.multiselect(
+        "Choose the goals that matter to you",
+        [
+            "Maximise track coverage",
+            "Maximise straight running",
+            "Include loops",
+            "Include spurs/sidings",
+            "Include fiddle yard",
+            "Minimise total track",
+            "Encourage complex operations",
+            "Prefer multiple loops",
+        ],
+        default=["Include loops"],
+    )
+
+    allowed_radii = st.sidebar.multiselect(
+        "Allowed curve radii",
+        options=[371.0, 438.0, 505.0, 572.0],
+        format_func=lambda v: f"{v:.0f} mm",
+        default=[371.0, 438.0, 505.0, 572.0],
+    )
+    return objectives, allowed_radii
+
+
+def _render_plan(plan: LayoutPlan, board: BoardSpecification) -> None:
+    total_length = plan.total_length_mm() / 1000
+    straight_length = plan.straight_length_mm() / 1000
+    curve_length = plan.curve_length_mm() / 1000
+    breakdown = pd.DataFrame(
+        plan.piece_breakdown(), columns=["Catalogue", "Piece", "Quantity"]
+    )
+
+    col1, col2 = st.columns([1, 1])
+    with col1:
+        st.subheader(plan.name)
+        st.write(plan.description)
+        st.metric("Total track length", f"{total_length:.2f} m")
+        st.metric("Straight sections", f"{straight_length:.2f} m")
+        st.metric("Curved sections", f"{curve_length:.2f} m")
+        st.write("**Features:** " + ", ".join(sorted(plan.features)))
+        if plan.notes:
+            st.markdown("**Notes:**")
+            for note in plan.notes:
+                st.markdown(f"- {note}")
+        st.dataframe(breakdown, hide_index=True, use_container_width=True)
+
+    with col2:
+        geometry = plan.build_geometry()
+        width, height = board.bounding_box()
+        fig, ax = plt.subplots(figsize=(6, 4))
+        draw_geometry(geometry, ax)
+        half_width = width / 2
+        half_height = height / 2
+        ax.add_patch(
+            plt.Rectangle(
+                (-half_width, -half_height),
+                width,
+                height,
+                fill=False,
+                edgecolor="#555555",
+                linestyle=":",
+                linewidth=1.5,
+            )
+        )
+        ax.set_aspect("equal", adjustable="box")
+        ax.set_title("Track geometry preview")
+        ax.set_xlabel("mm")
+        ax.set_ylabel("mm")
+        ax.grid(True, linestyle=":", linewidth=0.5)
+        ax.set_xlim(-half_width - 200, half_width + 200)
+        ax.set_ylim(-half_height - 200, half_height + 200)
+        st.pyplot(fig, clear_figure=True)
+
+
+board = _board_controls()
+objectives, allowed_radii = _objective_controls()
+st.sidebar.header("Results")
+max_layouts = st.sidebar.slider("Number of layout options", min_value=1, max_value=6, value=3)
+
+st.info(describe_board(board))
+
+if allowed_radii:
+    allowed_radii_set = set(allowed_radii)
+else:
+    allowed_radii_set = set()
+
+generator = get_generator()
+layouts = generator.generate(board, set(objectives), allowed_radii_set, max_layouts=max_layouts)
+
+if not layouts:
+    st.warning("No layouts match the chosen board size and goals. Try expanding the allowed radii or relaxing priorities.")
+else:
+    for plan in layouts:
+        st.divider()
+        _render_plan(plan, board)

--- a/planner.py
+++ b/planner.py
@@ -1,0 +1,480 @@
+"""Layout planning utilities for the Streamlit Hornby OO gauge planner app."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+
+import math
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+@dataclass(frozen=True)
+class TrackPiece:
+    """Represents a single catalogue item from the Hornby track range."""
+
+    code: str
+    name: str
+    kind: str
+    length: float  # straight length or equivalent primary dimension in mm
+    angle: Optional[float] = None  # degrees for curves
+    radius: Optional[float] = None  # mm for curves
+
+    def arc_length(self) -> float:
+        """Return the length along the centreline for curved pieces."""
+        if self.kind != "curve" or self.angle is None or self.radius is None:
+            return 0.0
+        return 2 * math.pi * self.radius * (self.angle / 360.0)
+
+
+TRACK_LIBRARY: Dict[str, TrackPiece] = {
+    "R600": TrackPiece("R600", "Standard Straight", "straight", 168.0),
+    "R601": TrackPiece("R601", "Double Straight", "straight", 335.5),
+    "R603": TrackPiece("R603", "Half Straight", "straight", 67.0),
+    "R604": TrackPiece("R604", "Quarter Straight", "straight", 41.0),
+    "R606": TrackPiece("R606", "1st Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=371.0),
+    "R607": TrackPiece("R607", "2nd Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=438.0),
+    "R608": TrackPiece("R608", "3rd Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=505.0),
+    "R609": TrackPiece("R609", "4th Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=572.0),
+    "R610": TrackPiece("R610", "1st Radius Curve (22.5°)", "curve", length=0.0, angle=22.5, radius=371.0),
+    "R614": TrackPiece("R614", "90° Crossing", "special", 168.0),
+    "R8072": TrackPiece("R8072", "Left-hand Point", "point", 168.0),
+    "R8073": TrackPiece("R8073", "Right-hand Point", "point", 168.0),
+}
+
+
+@dataclass
+class GeometryCommand:
+    """Instruction used to draw the preview of a layout."""
+
+    command: str
+    parameters: Tuple[float, ...]
+
+
+@dataclass
+class LayoutPlan:
+    """Full definition of a layout proposal."""
+
+    name: str
+    description: str
+    pieces: Dict[str, int]
+    footprint: Tuple[float, float]
+    features: Set[str]
+    radii_used: Set[float]
+    notes: List[str] = field(default_factory=list)
+    geometry_factory: Optional[Callable[["LayoutPlan"], List[GeometryCommand]]] = None
+
+    def total_length_mm(self) -> float:
+        total = 0.0
+        for code, count in self.pieces.items():
+            piece = TRACK_LIBRARY.get(code)
+            if not piece:
+                continue
+            if piece.kind == "curve":
+                total += piece.arc_length() * count
+            else:
+                total += piece.length * count
+        return total
+
+    def straight_length_mm(self) -> float:
+        total = 0.0
+        for code, count in self.pieces.items():
+            piece = TRACK_LIBRARY.get(code)
+            if not piece:
+                continue
+            if piece.kind in {"straight", "point", "special"}:
+                total += piece.length * count
+        return total
+
+    def curve_length_mm(self) -> float:
+        total = 0.0
+        for code, count in self.pieces.items():
+            piece = TRACK_LIBRARY.get(code)
+            if not piece:
+                continue
+            if piece.kind == "curve":
+                total += piece.arc_length() * count
+        return total
+
+    def piece_breakdown(self) -> List[Tuple[str, str, int]]:
+        breakdown: List[Tuple[str, str, int]] = []
+        for code, count in sorted(self.pieces.items()):
+            piece = TRACK_LIBRARY.get(code)
+            name = piece.name if piece else "Unknown"
+            breakdown.append((code, name, count))
+        return breakdown
+
+    def build_geometry(self) -> List[GeometryCommand]:
+        if self.geometry_factory is None:
+            return []
+        return self.geometry_factory(self)
+
+    def fits_within(self, width: float, height: float) -> bool:
+        footprint_width, footprint_height = self.footprint
+        return footprint_width <= width and footprint_height <= height
+
+
+@dataclass
+class BoardSpecification:
+    shape: str
+    width: float
+    height: float
+    polygon: Optional[List[Tuple[float, float]]] = None
+
+    def bounding_box(self) -> Tuple[float, float]:
+        if self.shape == "custom" and self.polygon:
+            xs = [p[0] for p in self.polygon]
+            ys = [p[1] for p in self.polygon]
+            return max(xs) - min(xs), max(ys) - min(ys)
+        return self.width, self.height
+
+
+def _oval_points(radius: float, straight_total: float, offset: Tuple[float, float] = (0.0, 0.0), samples: int = 120) -> np.ndarray:
+    """Create a closed oval represented as (x, y) points."""
+    ox, oy = offset
+    half_straight = straight_total / 2.0
+    top = np.column_stack(
+        [np.linspace(half_straight, -half_straight, samples // 4), np.full(samples // 4, radius)]
+    )
+    bottom = np.column_stack(
+        [np.linspace(-half_straight, half_straight, samples // 4), np.full(samples // 4, -radius)]
+    )
+    theta_left = np.linspace(math.pi / 2, 3 * math.pi / 2, samples // 4)
+    left = np.column_stack(
+        [-half_straight + radius * np.cos(theta_left), radius * np.sin(theta_left)]
+    )
+    theta_right = np.linspace(-math.pi / 2, math.pi / 2, samples // 4)
+    right = np.column_stack(
+        [half_straight + radius * np.cos(theta_right), radius * np.sin(theta_right)]
+    )
+    points = np.vstack([top, left, bottom, right, top[:1]])
+    points[:, 0] += ox
+    points[:, 1] += oy
+    return points
+
+
+def draw_geometry(commands: Sequence[GeometryCommand], ax: plt.Axes) -> None:
+    for command in commands:
+        if command.command == "oval":
+            radius, straight_total, ox, oy = command.parameters
+            pts = _oval_points(radius, straight_total, (ox, oy))
+            ax.plot(pts[:, 0], pts[:, 1], color="#1f77b4", linewidth=2)
+        elif command.command == "line":
+            x1, y1, x2, y2 = command.parameters
+            ax.plot([x1, x2], [y1, y2], color="#1f77b4", linewidth=2)
+        elif command.command == "siding":
+            x1, y1, x2, y2 = command.parameters
+            ax.plot([x1, x2], [y1, y2], color="#ff7f0e", linewidth=2, linestyle="--")
+        elif command.command == "marker":
+            x, y = command.parameters
+            ax.scatter([x], [y], s=20, color="#2ca02c")
+
+
+class LayoutGenerator:
+    """Selects layout templates that meet the user's brief."""
+
+    def __init__(self, templates: Iterable[LayoutPlan]):
+        self.templates = list(templates)
+
+    def generate(
+        self,
+        board: BoardSpecification,
+        objectives: Set[str],
+        allowed_radii: Set[float],
+        max_layouts: int = 5,
+    ) -> List[LayoutPlan]:
+        width, height = board.bounding_box()
+        required_features = set()
+        if "Include loops" in objectives:
+            required_features.add("loop")
+        if "Include spurs/sidings" in objectives:
+            required_features.add("spur")
+        if "Include fiddle yard" in objectives:
+            required_features.add("fiddle_yard")
+
+        candidates: List[Tuple[float, LayoutPlan]] = []
+        for template in self.templates:
+            if not template.fits_within(width, height):
+                continue
+            if required_features and not required_features.issubset(template.features):
+                continue
+            if allowed_radii and not template.radii_used.issubset(allowed_radii):
+                continue
+
+            score = self._score(template, objectives)
+            candidates.append((score, template))
+
+        reverse = True
+        if "Minimise total track" in objectives and "Maximise track coverage" not in objectives:
+            reverse = False
+
+        candidates.sort(key=lambda item: item[0], reverse=reverse)
+        return [tpl for _, tpl in candidates[:max_layouts]]
+
+    def _score(self, template: LayoutPlan, objectives: Set[str]) -> float:
+        total = template.total_length_mm()
+        straights = template.straight_length_mm()
+        score = 0.0
+        if not objectives:
+            score = total
+        if "Maximise track coverage" in objectives:
+            score += total
+        if "Maximise straight running" in objectives:
+            score += straights * 1.25
+        if "Minimise total track" in objectives:
+            score -= total
+        if "Encourage complex operations" in objectives and "fiddle_yard" in template.features:
+            score += 500.0
+        if "Encourage complex operations" in objectives and "spur" in template.features:
+            score += 250.0
+        if "Prefer multiple loops" in objectives and "multi_loop" in template.features:
+            score += 500.0
+        return score
+
+
+CLEARANCE = 120.0  # mm of margin around templates to give realistic space
+
+
+def _oval_geometry_factory(radius: float, straight_count: int, straight_code: str) -> Callable[[LayoutPlan], List[GeometryCommand]]:
+    piece = TRACK_LIBRARY[straight_code]
+    straight_total = piece.length * (straight_count / 2)
+
+    def factory(_: LayoutPlan) -> List[GeometryCommand]:
+        return [GeometryCommand("oval", (radius, straight_total, 0.0, 0.0))]
+
+    return factory
+
+
+def _oval_with_siding_geometry_factory(radius: float, straight_code: str, siding_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
+    piece = TRACK_LIBRARY[straight_code]
+    straight_total = piece.length * 2
+
+    def factory(_: LayoutPlan) -> List[GeometryCommand]:
+        commands = [GeometryCommand("oval", (radius, straight_total, 0.0, 0.0))]
+        commands.append(
+            GeometryCommand(
+                "siding",
+                (-straight_total / 2, radius + 60.0, -straight_total / 2 - siding_length, radius + 60.0),
+            )
+        )
+        commands.append(
+            GeometryCommand(
+                "siding",
+                (-straight_total / 2 + 30.0, radius + 60.0, -straight_total / 2 + 30.0, radius + 120.0),
+            )
+        )
+        return commands
+
+    return factory
+
+
+def _double_oval_geometry_factory(inner_radius: float, outer_radius: float, straight_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
+    half = straight_length
+
+    def factory(_: LayoutPlan) -> List[GeometryCommand]:
+        commands = [
+            GeometryCommand("oval", (outer_radius, half * 2, 0.0, 0.0)),
+            GeometryCommand("oval", (inner_radius, (half - 60.0) * 2, 0.0, 0.0)),
+            GeometryCommand("line", (-half - inner_radius, 0.0, -half - inner_radius, -200.0)),
+            GeometryCommand("line", (-half - inner_radius, -200.0, -half + inner_radius, -200.0)),
+        ]
+        return commands
+
+    return factory
+
+
+def _figure_eight_geometry_factory(radius: float, straight_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
+    half = straight_length / 2
+
+    def factory(_: LayoutPlan) -> List[GeometryCommand]:
+        left_center = (-half, 0.0)
+        right_center = (half, 0.0)
+        commands = [GeometryCommand("line", (left_center[0], radius, right_center[0], -radius))]
+        commands.append(GeometryCommand("oval", (radius, straight_length, *left_center)))
+        commands.append(GeometryCommand("oval", (radius, straight_length, *right_center)))
+        return commands
+
+    return factory
+
+
+def _fiddle_yard_geometry_factory(main_length: float, sidings: int, spacing: float = 70.0) -> Callable[[LayoutPlan], List[GeometryCommand]]:
+    def factory(_: LayoutPlan) -> List[GeometryCommand]:
+        commands = [GeometryCommand("line", (-main_length / 2, 0.0, main_length / 2, 0.0))]
+        for i in range(1, sidings + 1):
+            offset = i * spacing
+            commands.append(GeometryCommand("siding", (-main_length / 2 + 200.0, offset, main_length / 2, offset)))
+        return commands
+
+    return factory
+
+
+def default_templates() -> List[LayoutPlan]:
+    templates: List[LayoutPlan] = []
+
+    # Compact oval (1st radius)
+    radius = TRACK_LIBRARY["R606"].radius or 0.0
+    straight_piece = TRACK_LIBRARY["R600"].length
+    straight_total = straight_piece * 2
+    footprint = (2 * radius + straight_total + CLEARANCE, 2 * radius + CLEARANCE)
+    templates.append(
+        LayoutPlan(
+            name="Compact Continuous Oval",
+            description="A simple 1st radius oval ideal for very small boards and continuous running.",
+            pieces={"R606": 8, "R600": 4},
+            footprint=footprint,
+            features={"loop", "compact"},
+            radii_used={radius},
+            notes=["Add power clips to any straight for track power."],
+            geometry_factory=_oval_geometry_factory(radius, 4, "R600"),
+        )
+    )
+
+    # Standard oval with passing loop
+    radius = TRACK_LIBRARY["R607"].radius or 0.0
+    straight_length = TRACK_LIBRARY["R600"].length
+    straight_total = straight_length * 2
+    footprint = (2 * radius + straight_total + CLEARANCE + 180.0, 2 * radius + CLEARANCE + 140.0)
+    templates.append(
+        LayoutPlan(
+            name="Passing Loop Oval",
+            description="2nd radius oval with a passing loop for two-train operation or station stops.",
+            pieces={
+                "R607": 8,
+                "R600": 6,
+                "R603": 2,
+                "R8072": 1,
+                "R8073": 1,
+            },
+            footprint=footprint,
+            features={"loop", "spur"},
+            radii_used={radius},
+            notes=["Points form a loop on the top straight allowing trains to pass."],
+            geometry_factory=_oval_with_siding_geometry_factory(radius, "R600", 400.0),
+        )
+    )
+
+    # Double track oval
+    inner_radius = TRACK_LIBRARY["R607"].radius or 0.0
+    outer_radius = TRACK_LIBRARY["R608"].radius or 0.0
+    straight_length = TRACK_LIBRARY["R600"].length * 2
+    footprint = (2 * outer_radius + straight_length + CLEARANCE + 160.0, 2 * outer_radius + CLEARANCE + 120.0)
+    templates.append(
+        LayoutPlan(
+            name="Twin Track Mainline",
+            description="Paired 2nd and 3rd radius loops for continuous two-train running with a crossover.",
+            pieces={
+                "R608": 8,
+                "R607": 8,
+                "R600": 8,
+                "R8072": 2,
+                "R8073": 2,
+            },
+            footprint=footprint,
+            features={"loop", "multi_loop", "max_track"},
+            radii_used={inner_radius, outer_radius},
+            notes=["Use opposing points as a scissors crossover between the loops."],
+            geometry_factory=_double_oval_geometry_factory(inner_radius, outer_radius, straight_length / 2),
+        )
+    )
+
+    # Large oval with fiddle yard
+    radius = TRACK_LIBRARY["R609"].radius or 0.0
+    straight_length = TRACK_LIBRARY["R601"].length * 2
+    footprint = (2 * radius + straight_length + CLEARANCE + 420.0, 2 * radius + CLEARANCE + 200.0)
+    templates.append(
+        LayoutPlan(
+            name="Mainline with Fiddle Yard",
+            description="4th radius oval with extended straights feeding a three-road fiddle yard.",
+            pieces={
+                "R609": 8,
+                "R601": 4,
+                "R8072": 3,
+                "R8073": 3,
+                "R600": 6,
+            },
+            footprint=footprint,
+            features={"loop", "fiddle_yard", "spur", "max_track"},
+            radii_used={radius},
+            notes=["Three sidings can store full-length trains ready to enter the mainline."],
+            geometry_factory=_fiddle_yard_geometry_factory(straight_length + 2 * radius, sidings=3),
+        )
+    )
+
+    # End-to-end with fiddle yard
+    main_length = 2400.0
+    footprint = (main_length + CLEARANCE, 600.0 + CLEARANCE)
+    templates.append(
+        LayoutPlan(
+            name="End-to-End Terminus",
+            description="End-to-end layout with a three road fiddle yard and long platform straight.",
+            pieces={
+                "R601": 8,
+                "R600": 6,
+                "R603": 4,
+                "R8072": 3,
+                "R8073": 3,
+            },
+            footprint=footprint,
+            features={"fiddle_yard", "spur", "terminus"},
+            radii_used=set(),
+            notes=["Ideal for shunting and timetable operations without requiring continuous running."],
+            geometry_factory=_fiddle_yard_geometry_factory(main_length, sidings=3),
+        )
+    )
+
+    # Compact shunting puzzle
+    footprint = (1600.0 + CLEARANCE, 600.0 + CLEARANCE)
+    templates.append(
+        LayoutPlan(
+            name="Shunting Puzzle Yard",
+            description="A Inglenook-inspired yard using set-track pieces for switching challenges.",
+            pieces={
+                "R600": 10,
+                "R603": 6,
+                "R604": 4,
+                "R8072": 2,
+                "R8073": 1,
+            },
+            footprint=footprint,
+            features={"spur", "operations"},
+            radii_used=set(),
+            notes=["Lengths suit three wagon trains in the longest siding and two wagons elsewhere."],
+            geometry_factory=_fiddle_yard_geometry_factory(1200.0, sidings=2),
+        )
+    )
+
+    # Figure eight continuous run
+    radius = TRACK_LIBRARY["R607"].radius or 0.0
+    straight_length = TRACK_LIBRARY["R600"].length * 2
+    footprint = (straight_length * 2 + 2 * radius + CLEARANCE, 2 * radius + straight_length + CLEARANCE)
+    templates.append(
+        LayoutPlan(
+            name="Figure Eight with Crossing",
+            description="Continuous run with grade-level crossover for visual interest and reversing loops.",
+            pieces={
+                "R607": 16,
+                "R600": 4,
+                "R614": 1,
+            },
+            footprint=footprint,
+            features={"loop", "crossover", "max_track"},
+            radii_used={radius},
+            notes=["Consider using power districts to avoid shorts through the crossing."],
+            geometry_factory=_figure_eight_geometry_factory(radius, straight_length),
+        )
+    )
+
+    return templates
+
+
+def describe_board(board: BoardSpecification) -> str:
+    width, height = board.bounding_box()
+    dims = f"{width/1000:.2f} m x {height/1000:.2f} m"
+    if board.shape == "rectangle":
+        return f"Rectangular board {dims}"
+    if board.shape == "l-shape":
+        return f"L-shaped board envelope {dims}"
+    if board.shape == "custom":
+        return f"Custom board bounding box {dims}"
+    return dims

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+matplotlib==3.8.4
+numpy==1.26.4
+pandas==2.2.2
+streamlit==1.34.0


### PR DESCRIPTION
## Summary
- add a planner module with Hornby track library, layout templates, and drawing utilities
- build a Streamlit UI so users can pick board shapes and objectives to preview suggested layouts
- document installation instructions and pin requirements for running the app

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68dedac0b0d08324badb61bd95c455b4