### PR TITLE
Use lightweight SVG rendering for track previews

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-matplotlib==3.8.4
-numpy==1.26.4
-pandas==2.2.2
 streamlit==1.34.0


### PR DESCRIPTION
## Summary
- replace the sidebar data editor with a simple text-area based polygon entry that validates input and warns on bad rows
- render layout previews as inline SVG so no matplotlib/numpy stack is required
- shrink the dependency list to Streamlit only for faster installs on Streamlit Cloud

## Testing
- python -m compileall app.py planner.py

------
https://chatgpt.com/codex/tasks/task_e_68dee2ed51c883249bd0a0cd34f0d5bf