### PR TITLE
Replace generator with interactive board designer

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,158 +1,839 @@
-from typing import List, Tuple
+import json
+from dataclasses import asdict
+from typing import Dict, List, Optional, Sequence, Tuple
 
-import matplotlib.pyplot as plt
-import pandas as pd
 import streamlit as st
+import streamlit.components.v1 as components
 
 from planner import (
-    BoardSpecification,
-    LayoutGenerator,
-    LayoutPlan,
-    describe_board,
-    default_templates,
-    draw_geometry,
+    TRACK_LIBRARY,
+    TrackPiece,
+    board_polygon_for_l_shape,
+    board_polygon_for_rectangle,
+    compute_piece_counts,
+    normalise_polygon,
+    polygon_bounds,
+    total_run_length_mm,
 )
 
 
-st.set_page_config(page_title="Hornby OO Layout Planner", layout="wide")
-st.title("Hornby OO Gauge Layout Planner")
-st.write(
-    """Design OO gauge train set plans by choosing a baseboard size and the features you would like in your layout.\n"
-    "The planner uses real-world Hornby set-track dimensions to recommend track plans that fit within your available space."""
-)
+st.set_page_config(page_title="Hornby OO Gauge Board Planner", layout="wide")
 
 
-@st.cache_resource
-def get_generator() -> LayoutGenerator:
-    return LayoutGenerator(default_templates())
-
-
-def _board_controls() -> BoardSpecification:
-    st.sidebar.header("Board")
+def _board_controls() -> Tuple[Dict[str, float], List[Tuple[float, float]]]:
+    st.sidebar.header("Board configuration")
     shape = st.sidebar.selectbox("Board shape", ["Rectangle", "L-Shape", "Custom polygon"], index=0)
 
     if shape == "Rectangle":
-        width = st.sidebar.number_input("Width (mm)", min_value=600.0, value=1800.0, step=50.0)
-        height = st.sidebar.number_input("Depth (mm)", min_value=450.0, value=1200.0, step=50.0)
-        return BoardSpecification(shape="rectangle", width=width, height=height)
+        width = st.sidebar.number_input("Width (mm)", min_value=600.0, value=2400.0, step=50.0)
+        depth = st.sidebar.number_input("Depth (mm)", min_value=450.0, value=1200.0, step=50.0)
+        polygon = board_polygon_for_rectangle(width, depth)
+        return {"shape": "rectangle", "width": width, "height": depth}, polygon
 
     if shape == "L-Shape":
-        long_leg = st.sidebar.number_input("Long leg length (mm)", min_value=1000.0, value=2400.0, step=50.0)
-        short_leg = st.sidebar.number_input("Short leg length (mm)", min_value=800.0, value=1500.0, step=50.0)
-        width = st.sidebar.number_input("Overall width (mm)", min_value=600.0, value=900.0, step=25.0)
-        polygon = [(0.0, 0.0), (long_leg, 0.0), (long_leg, width), (width, width), (width, short_leg), (0.0, short_leg)]
-        return BoardSpecification(shape="l-shape", width=long_leg, height=short_leg, polygon=polygon)
+        long_leg = st.sidebar.number_input("Long leg (mm)", min_value=1200.0, value=2400.0, step=50.0)
+        short_leg = st.sidebar.number_input("Short leg (mm)", min_value=900.0, value=1500.0, step=50.0)
+        depth = st.sidebar.number_input("Depth (mm)", min_value=450.0, value=900.0, step=25.0)
+        polygon = board_polygon_for_l_shape(long_leg, short_leg, depth)
+        return {"shape": "l-shape", "width": long_leg, "height": short_leg}, polygon
 
-    st.sidebar.markdown("Enter the corner points of your board outline in millimetres.")
-    default_points: List[Tuple[float, float]] = [(0.0, 0.0), (2400.0, 0.0), (2400.0, 1200.0), (0.0, 1200.0)]
-    data = st.sidebar.data_editor(
-        pd.DataFrame(default_points, columns=["x", "y"]),
-        num_rows="dynamic",
-        key="custom_polygon",
+    st.sidebar.markdown(
+        "Enter corner points in millimetres, one per line as `x,y`. Points are connected in the order provided."
     )
-    polygon = list(data.itertuples(index=False, name=None))
-    return BoardSpecification(
-        shape="custom",
-        width=max(p[0] for p in polygon) if polygon else 0.0,
-        height=max(p[1] for p in polygon) if polygon else 0.0,
-        polygon=polygon,
+    default_points = "\n".join(["0,0", "2400,0", "2400,1200", "0,1200"])
+    raw_points = st.sidebar.text_area("Polygon points", value=default_points, height=150, key="custom_polygon_input")
+    polygon: List[Tuple[float, float]] = []
+    invalid = 0
+    for line in raw_points.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split(",")
+        if len(parts) != 2:
+            invalid += 1
+            continue
+        try:
+            x_val = float(parts[0].strip())
+            y_val = float(parts[1].strip())
+        except ValueError:
+            invalid += 1
+            continue
+        polygon.append((x_val, y_val))
+
+    if invalid:
+        st.sidebar.warning(f"Skipped {invalid} invalid coordinate line{'s' if invalid != 1 else ''}.")
+
+    polygon = normalise_polygon(polygon)
+    width, height = polygon_bounds(polygon)
+    return {"shape": "polygon", "width": width, "height": height}, polygon
+
+
+def _grid_controls() -> Dict[str, float]:
+    st.sidebar.header("Layout helpers")
+    snap = st.sidebar.number_input("Grid snap (mm)", min_value=1.0, value=25.0, step=1.0)
+    fine_snap = st.sidebar.number_input("Fine snap (mm)", min_value=0.5, value=5.0, step=0.5)
+    return {"snap": snap, "fineSnap": fine_snap}
+
+
+def _prepare_library_for_js(pieces: Sequence[TrackPiece]) -> List[Dict[str, object]]:
+    rows: List[Dict[str, object]] = []
+    for piece in pieces:
+        row = asdict(piece)
+        rows.append(row)
+    return rows
+
+
+def _build_designer_html(
+    board: Dict[str, float],
+    polygon: Sequence[Tuple[float, float]],
+    grid: Dict[str, float],
+    pieces: Sequence[TrackPiece],
+    existing_state: Optional[Dict[str, object]],
+) -> str:
+    polygon_json = json.dumps(polygon)
+    board_json = json.dumps(board)
+    grid_json = json.dumps(grid)
+    library_json = json.dumps(_prepare_library_for_js(pieces))
+    state_json = json.dumps(existing_state or {"placements": []})
+
+    template = """
+<style>
+    .planner-wrapper {
+        display: grid;
+        grid-template-columns: 260px minmax(420px, 1fr) 240px;
+        gap: 1.25rem;
+        font-family: 'Inter', sans-serif;
+    }
+    .planner-pane {
+        background: #ffffff;
+        border: 1px solid #d9d9d9;
+        border-radius: 8px;
+        padding: 0.75rem 0.9rem;
+        box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+        display: flex;
+        flex-direction: column;
+    }
+    .planner-pane h3 {
+        margin: 0 0 0.5rem;
+        font-size: 1.05rem;
+        font-weight: 600;
+    }
+    .library-list {
+        overflow-y: auto;
+        flex: 1;
+        border-top: 1px solid #e6e6e6;
+        padding-top: 0.5rem;
+    }
+    .library-item {
+        border: 1px solid #e0e0e0;
+        border-radius: 6px;
+        padding: 0.45rem 0.5rem;
+        margin-bottom: 0.45rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        background: #fafafa;
+    }
+    .library-item button {
+        align-self: flex-start;
+        background: #ff4b4b;
+        border: none;
+        color: white;
+        border-radius: 4px;
+        padding: 0.25rem 0.6rem;
+        cursor: pointer;
+        font-size: 0.82rem;
+    }
+    .library-item button:hover {
+        background: #ff2d2d;
+    }
+    .board-pane {
+        position: relative;
+        min-height: 520px;
+    }
+    .board-svg {
+        width: 100%;
+        height: 100%;
+        background: #f9fafb;
+        border-radius: 8px;
+    }
+    .board-instructions {
+        font-size: 0.82rem;
+        color: #555555;
+        margin-top: 0.5rem;
+        line-height: 1.4;
+    }
+    .board-instructions code {
+        background: #f0f0f0;
+        padding: 0.05rem 0.25rem;
+        border-radius: 3px;
+        font-size: 0.78rem;
+    }
+    .piece {
+        cursor: grab;
+    }
+    .piece.dragging {
+        cursor: grabbing;
+    }
+    .piece path {
+        fill: #d1d5db;
+        stroke: #374151;
+        stroke-width: 1.6;
+    }
+    .piece.selected path {
+        stroke: #fb923c;
+        stroke-width: 2.2;
+    }
+    .endpoint {
+        fill: #9ca3af;
+        stroke: #1f2937;
+        stroke-width: 0.6;
+    }
+    .endpoint.connected {
+        fill: #10b981;
+    }
+    .inventory-list {
+        flex: 1;
+        overflow-y: auto;
+        border-top: 1px solid #e6e6e6;
+        padding-top: 0.5rem;
+        font-size: 0.85rem;
+    }
+    .inventory-list table {
+        width: 100%;
+        border-collapse: collapse;
+    }
+    .inventory-list th,
+    .inventory-list td {
+        text-align: left;
+        padding: 0.2rem 0.1rem;
+        border-bottom: 1px solid #ececec;
+    }
+    .inventory-empty {
+        color: #6b7280;
+        font-style: italic;
+    }
+</style>
+<div class="planner-wrapper">
+  <div class="planner-pane">
+    <h3>Track library</h3>
+    <div class="library-list" id="library-list"></div>
+  </div>
+  <div class="planner-pane board-pane">
+    <svg class="board-svg" id="board-canvas" viewBox="0 0 10 10"></svg>
+    <div class="board-instructions">
+        Drag pieces onto the board. Use <code>R</code>/<code>Shift+R</code> to rotate, <code>F</code> to flip, arrow keys to nudge, and <code>Delete</code> to remove the selected piece. Hold <code>Alt</code> while dragging to temporarily disable grid snapping.
+    </div>
+  </div>
+  <div class="planner-pane">
+    <h3>Placed pieces</h3>
+    <div class="inventory-list" id="inventory"></div>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/streamlit-component-lib@1.2.0/dist/index.min.js"></script>
+<script>
+const BOARD = __BOARD__;
+const POLYGON = __POLYGON__;
+const GRID = __GRID__;
+const LIBRARY = __LIBRARY__;
+let state = __STATE__;
+let placements = Array.isArray(state.placements) ? state.placements.slice() : [];
+let selectedId = null;
+let dragInfo = null;
+let syncTimer = null;
+
+const SNAP = GRID.snap || 1.0;
+const FINE_SNAP = GRID.fineSnap || Math.max(SNAP / 5, 1.0);
+
+const libraryList = document.getElementById('library-list');
+const inventoryList = document.getElementById('inventory');
+const svg = document.getElementById('board-canvas');
+
+const mmBounds = (() => {
+    if (!Array.isArray(POLYGON) || !POLYGON.length) {
+        return { minX: 0, minY: 0, width: BOARD.width || 0, height: BOARD.height || 0 };
+    }
+    let minX = POLYGON[0][0];
+    let minY = POLYGON[0][1];
+    let maxX = POLYGON[0][0];
+    let maxY = POLYGON[0][1];
+    POLYGON.forEach(([x, y]) => {
+        if (x < minX) minX = x;
+        if (y < minY) minY = y;
+        if (x > maxX) maxX = x;
+        if (y > maxY) maxY = y;
+    });
+    return { minX, minY, width: maxX - minX, height: maxY - minY };
+})();
+
+const toSvgPoint = (clientX, clientY) => {
+    const point = svg.createSVGPoint();
+    point.x = clientX;
+    point.y = clientY;
+    const inverted = point.matrixTransform(svg.getScreenCTM().inverse());
+    return { x: inverted.x, y: inverted.y };
+};
+
+const snapValue = (value, increment) => {
+    if (!increment || increment <= 0) return value;
+    return Math.round(value / increment) * increment;
+};
+
+const createPiecePath = (piece) => {
+    const halfWidth = 16; // Hornby track is ~32mm wide
+    if (piece.kind === 'straight' || piece.kind === 'point' || piece.kind === 'accessory' || piece.kind === 'crossover') {
+        const len = piece.length || 0;
+        return `M 0 ${-halfWidth} L ${len} ${-halfWidth} L ${len} ${halfWidth} L 0 ${halfWidth} Z`;
+    }
+    if (piece.kind === 'curve') {
+        const radius = piece.radius || 0;
+        const angle = (piece.angle || 0) * Math.PI / 180;
+        const largeArc = (piece.angle || 0) > 180 ? 1 : 0;
+        const outer = radius + halfWidth;
+        const inner = Math.max(radius - halfWidth, 1);
+        const thetaEnd = angle - Math.PI / 2;
+        const outerEndX = outer * Math.cos(thetaEnd);
+        const outerEndY = radius + outer * Math.sin(thetaEnd);
+        const innerEndX = inner * Math.cos(thetaEnd);
+        const innerEndY = radius + inner * Math.sin(thetaEnd);
+        return [
+            `M 0 ${-halfWidth}`,
+            `A ${outer} ${outer} 0 ${largeArc} 1 ${outerEndX} ${outerEndY}`,
+            `L ${innerEndX} ${innerEndY}`,
+            `A ${inner} ${inner} 0 ${largeArc} 0 0 ${halfWidth}`,
+            'Z',
+        ].join(' ');
+    }
+    return '';
+};
+
+const pieceLocalEnd = (piece) => {
+    if (piece.kind === 'curve') {
+        const radius = piece.radius || 0;
+        const angleRad = (piece.angle || 0) * Math.PI / 180;
+        const x = radius * Math.cos(angleRad - Math.PI / 2);
+        const y = radius + radius * Math.sin(angleRad - Math.PI / 2);
+        return { x, y };
+    }
+    const len = piece.length || 0;
+    return { x: len, y: 0 };
+};
+
+const transformPoint = (placement, point) => {
+    const scaleX = placement.flipped ? -1 : 1;
+    const angle = (placement.rotation || 0) * Math.PI / 180;
+    const xScaled = scaleX * point.x;
+    const yScaled = point.y;
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const xRot = xScaled * cos - yScaled * sin;
+    const yRot = xScaled * sin + yScaled * cos;
+    return { x: xRot + placement.x, y: yRot + placement.y };
+};
+
+const transformVector = (placement, vector) => {
+    const scaleX = placement.flipped ? -1 : 1;
+    const angle = (placement.rotation || 0) * Math.PI / 180;
+    const xScaled = scaleX * vector.x;
+    const yScaled = vector.y;
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    return { x: xScaled * cos - yScaled * sin, y: xScaled * sin + yScaled * cos };
+};
+
+const endpointsFor = (placement, piece) => {
+    const start = transformPoint(placement, { x: 0, y: 0 });
+    const endLocal = pieceLocalEnd(piece);
+    const end = transformPoint(placement, endLocal);
+    const dir = transformVector(placement, { x: 1, y: 0 });
+    const endDir = transformVector(placement, { x: Math.cos((piece.angle || 0) * Math.PI / 180), y: Math.sin((piece.angle || 0) * Math.PI / 180) });
+    return [
+        { x: start.x, y: start.y, dir },
+        { x: end.x, y: end.y, dir: endDir },
+    ];
+};
+
+const placementPath = (placement, piece) => {
+    const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    path.setAttribute('d', createPiecePath(piece));
+    return path;
+};
+
+const placementGroup = (placement, piece) => {
+    const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    g.classList.add('piece');
+    g.dataset.id = placement.id;
+    if (placement.id === selectedId) {
+        g.classList.add('selected');
+    }
+    const path = placementPath(placement, piece);
+    g.appendChild(path);
+
+    const endpoints = endpointsFor(placement, piece);
+    endpoints.forEach((pt, index) => {
+        const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        circle.classList.add('endpoint');
+        circle.dataset.endpoint = `${placement.id}:${index}`;
+        circle.setAttribute('cx', pt.x);
+        circle.setAttribute('cy', pt.y);
+        circle.setAttribute('r', 6);
+        svgEndpoints.push({ element: circle, x: pt.x, y: pt.y });
+        g.appendChild(circle);
+    });
+
+    const transform = placementTransform(placement);
+    g.setAttribute('transform', transform);
+    return g;
+};
+
+const placementTransform = (placement) => {
+    const scaleX = placement.flipped ? -1 : 1;
+    const angle = placement.rotation || 0;
+    const cos = Math.cos(angle * Math.PI / 180);
+    const sin = Math.sin(angle * Math.PI / 180);
+    const a = cos * scaleX;
+    const b = sin * scaleX;
+    const c = -sin;
+    const d = cos;
+    const e = placement.x;
+    const f = placement.y;
+    return `matrix(${a} ${b} ${c} ${d} ${e} ${f})`;
+};
+
+const renderBoard = () => {
+    while (svg.firstChild) {
+        svg.removeChild(svg.firstChild);
+    }
+
+    const viewWidth = mmBounds.width || 10;
+    const viewHeight = mmBounds.height || 10;
+    svg.setAttribute('viewBox', `${mmBounds.minX} ${mmBounds.minY} ${viewWidth} ${viewHeight}`);
+
+    const gridGroup = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    gridGroup.setAttribute('stroke', '#e5e7eb');
+    gridGroup.setAttribute('stroke-width', 0.6);
+    const spacing = Math.max(SNAP, 10);
+    for (let x = 0; x <= viewWidth; x += spacing) {
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', mmBounds.minX + x);
+        line.setAttribute('y1', mmBounds.minY);
+        line.setAttribute('x2', mmBounds.minX + x);
+        line.setAttribute('y2', mmBounds.minY + viewHeight);
+        line.setAttribute('opacity', x % (spacing * 2) === 0 ? 0.6 : 0.3);
+        gridGroup.appendChild(line);
+    }
+    for (let y = 0; y <= viewHeight; y += spacing) {
+        const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        line.setAttribute('x1', mmBounds.minX);
+        line.setAttribute('y1', mmBounds.minY + y);
+        line.setAttribute('x2', mmBounds.minX + viewWidth);
+        line.setAttribute('y2', mmBounds.minY + y);
+        line.setAttribute('opacity', y % (spacing * 2) === 0 ? 0.6 : 0.3);
+        gridGroup.appendChild(line);
+    }
+    svg.appendChild(gridGroup);
+
+    const outline = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+    const poly = POLYGON.length ? POLYGON : [
+        [0, 0],
+        [BOARD.width || 0, 0],
+        [BOARD.width || 0, BOARD.height || 0],
+        [0, BOARD.height || 0],
+    ];
+    const d = poly.map((pt, index) => `${index ? 'L' : 'M'} ${pt[0]} ${pt[1]}`).join(' ') + ' Z';
+    outline.setAttribute('d', d);
+    outline.setAttribute('fill', '#fefefe');
+    outline.setAttribute('stroke', '#111827');
+    outline.setAttribute('stroke-width', 4);
+    svg.appendChild(outline);
+
+    svgPieces = document.createElementNS('http://www.w3.org/2000/svg', 'g');
+    svgPieces.setAttribute('id', 'svg-pieces');
+    svg.appendChild(svgPieces);
+
+    redrawPieces();
+};
+
+const redrawPieces = () => {
+    if (!svgPieces) return;
+    while (svgPieces.firstChild) {
+        svgPieces.removeChild(svgPieces.firstChild);
+    }
+    svgEndpoints = [];
+    placements.forEach((placement) => {
+        const piece = LIBRARY.find((item) => item.code === placement.code);
+        if (!piece) return;
+        const group = placementGroup(placement, piece);
+        svgPieces.appendChild(group);
+    });
+    highlightConnections();
+};
+
+const highlightConnections = () => {
+    const tolerance = 6;
+    svgEndpoints.forEach((endpoint) => {
+        endpoint.element.classList.remove('connected');
+    });
+    for (let i = 0; i < svgEndpoints.length; i += 1) {
+        for (let j = i + 1; j < svgEndpoints.length; j += 1) {
+            const a = svgEndpoints[i];
+            const b = svgEndpoints[j];
+            const dx = a.x - b.x;
+            const dy = a.y - b.y;
+            if (Math.hypot(dx, dy) <= tolerance) {
+                a.element.classList.add('connected');
+                b.element.classList.add('connected');
+            }
+        }
+    }
+};
+
+const updateInventory = () => {
+    const counts = {};
+    placements.forEach((placement) => {
+        counts[placement.code] = (counts[placement.code] || 0) + 1;
+    });
+    const codes = Object.keys(counts).sort();
+    if (!codes.length) {
+        inventoryList.innerHTML = '<p class="inventory-empty">No track has been placed yet.</p>';
+        return;
+    }
+    const rows = codes.map((code) => {
+        const piece = LIBRARY.find((item) => item.code === code);
+        const name = piece ? piece.name : 'Unknown piece';
+        return `<tr><td>${code}</td><td>${name}</td><td style="text-align:right;">${counts[code]}</td></tr>`;
+    }).join('');
+    inventoryList.innerHTML = `<table><thead><tr><th>Code</th><th>Piece</th><th style="text-align:right;">Qty</th></tr></thead><tbody>${rows}</tbody></table>`;
+};
+
+const scheduleSync = () => {
+    if (syncTimer) {
+        clearTimeout(syncTimer);
+    }
+    syncTimer = setTimeout(() => {
+        const payload = { placements: placements.map((p) => ({ ...p })) };
+        Streamlit.setComponentValue(JSON.stringify(payload));
+    }, 120);
+};
+
+const ensureIds = () => {
+    placements.forEach((placement, index) => {
+        if (!placement.id) {
+            placement.id = `piece-${Date.now()}-${index}-${Math.random().toString(36).slice(2, 7)}`;
+        }
+        if (typeof placement.rotation !== 'number') {
+            placement.rotation = 0;
+        }
+        if (typeof placement.x !== 'number') {
+            placement.x = (mmBounds.minX + mmBounds.width / 2) || 0;
+        }
+        if (typeof placement.y !== 'number') {
+            placement.y = (mmBounds.minY + mmBounds.height / 2) || 0;
+        }
+        if (typeof placement.flipped !== 'boolean') {
+            placement.flipped = false;
+        }
+    });
+};
+
+const addPiece = (code) => {
+    const piece = LIBRARY.find((item) => item.code === code);
+    if (!piece) return;
+    const placement = {
+        id: `piece-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        code,
+        x: (mmBounds.minX + mmBounds.width / 2) || 0,
+        y: (mmBounds.minY + mmBounds.height / 2) || 0,
+        rotation: 0,
+        flipped: false,
+    };
+    placements.push(placement);
+    selectedId = placement.id;
+    redrawPieces();
+    updateInventory();
+    scheduleSync();
+};
+
+const removeSelected = () => {
+    if (!selectedId) return;
+    placements = placements.filter((placement) => placement.id !== selectedId);
+    selectedId = null;
+    redrawPieces();
+    updateInventory();
+    scheduleSync();
+};
+
+const rotateSelected = (increment) => {
+    const placement = placements.find((item) => item.id === selectedId);
+    if (!placement) return;
+    placement.rotation = (placement.rotation + increment + 360) % 360;
+    redrawPieces();
+    updateInventory();
+    scheduleSync();
+};
+
+const flipSelected = () => {
+    const placement = placements.find((item) => item.id === selectedId);
+    if (!placement) return;
+    placement.flipped = !placement.flipped;
+    redrawPieces();
+    updateInventory();
+    scheduleSync();
+};
+
+const nudgeSelected = (dx, dy, fine) => {
+    const placement = placements.find((item) => item.id === selectedId);
+    if (!placement) return;
+    const snap = fine ? FINE_SNAP : SNAP;
+    placement.x = snapValue(placement.x + dx, snap);
+    placement.y = snapValue(placement.y + dy, snap);
+    redrawPieces();
+    updateInventory();
+    scheduleSync();
+};
+
+const handlePointerDown = (event) => {
+    const group = event.target.closest('.piece');
+    if (!group) return;
+    const id = group.dataset.id;
+    selectedId = id;
+    redrawPieces();
+    updateInventory();
+    const placement = placements.find((item) => item.id === id);
+    if (!placement) return;
+    group.classList.add('dragging');
+    const svgPoint = toSvgPoint(event.clientX, event.clientY);
+    dragInfo = {
+        id,
+        offsetX: svgPoint.x - placement.x,
+        offsetY: svgPoint.y - placement.y,
+        snapping: !event.altKey,
+    };
+    svg.setPointerCapture(event.pointerId);
+    event.preventDefault();
+};
+
+const handlePointerMove = (event) => {
+    if (!dragInfo) return;
+    const placement = placements.find((item) => item.id === dragInfo.id);
+    if (!placement) return;
+    const svgPoint = toSvgPoint(event.clientX, event.clientY);
+    const snap = event.shiftKey ? FINE_SNAP : SNAP;
+    let x = svgPoint.x - dragInfo.offsetX;
+    let y = svgPoint.y - dragInfo.offsetY;
+    if (dragInfo.snapping && !event.altKey) {
+        x = snapValue(x, snap);
+        y = snapValue(y, snap);
+    }
+    placement.x = x;
+    placement.y = y;
+    redrawPieces();
+    updateInventory();
+    scheduleSync();
+};
+
+const handlePointerUp = (event) => {
+    if (dragInfo) {
+        const group = svg.querySelector(`.piece[data-id="${dragInfo.id}"]`);
+        if (group) {
+            group.classList.remove('dragging');
+        }
+    }
+    dragInfo = null;
+    svg.releasePointerCapture(event.pointerId);
+};
+
+const handleClick = (event) => {
+    const group = event.target.closest('.piece');
+    if (!group) {
+        selectedId = null;
+        redrawPieces();
+        updateInventory();
+        return;
+    }
+    selectedId = group.dataset.id;
+    redrawPieces();
+    updateInventory();
+};
+
+svg.addEventListener('pointerdown', handlePointerDown);
+svg.addEventListener('pointermove', handlePointerMove);
+svg.addEventListener('pointerup', handlePointerUp);
+svg.addEventListener('pointerleave', handlePointerUp);
+svg.addEventListener('click', handleClick);
+
+window.addEventListener('keydown', (event) => {
+    if (!selectedId) return;
+    if (event.key === 'Delete' || event.key === 'Backspace') {
+        event.preventDefault();
+        removeSelected();
+    } else if (event.key.toLowerCase() === 'r') {
+        event.preventDefault();
+        rotateSelected(event.shiftKey ? 11.25 : 22.5);
+    } else if (event.key.toLowerCase() === 'f') {
+        event.preventDefault();
+        flipSelected();
+    } else if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        nudgeSelected(-SNAP, 0, event.shiftKey);
+    } else if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        nudgeSelected(SNAP, 0, event.shiftKey);
+    } else if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        nudgeSelected(0, -SNAP, event.shiftKey);
+    } else if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        nudgeSelected(0, SNAP, event.shiftKey);
+    }
+});
+
+const renderLibrary = () => {
+    const groups = {};
+    LIBRARY.forEach((piece) => {
+        const kind = piece.kind || 'other';
+        if (!groups[kind]) {
+            groups[kind] = [];
+        }
+        groups[kind].push(piece);
+    });
+    const order = ['straight', 'curve', 'point', 'crossover', 'accessory', 'other'];
+    libraryList.innerHTML = '';
+    order.forEach((kind) => {
+        if (!groups[kind] || !groups[kind].length) return;
+        const header = document.createElement('div');
+        header.style.fontWeight = '600';
+        header.style.margin = '0.35rem 0 0.2rem';
+        header.textContent = kind.charAt(0).toUpperCase() + kind.slice(1);
+        libraryList.appendChild(header);
+        groups[kind]
+            .sort((a, b) => a.code.localeCompare(b.code))
+            .forEach((piece) => {
+                const item = document.createElement('div');
+                item.className = 'library-item';
+                const title = document.createElement('div');
+                title.style.fontWeight = '600';
+                title.textContent = `${piece.code}`;
+                const subtitle = document.createElement('div');
+                subtitle.textContent = piece.name;
+                subtitle.style.fontSize = '0.82rem';
+                const details = document.createElement('div');
+                details.style.fontSize = '0.75rem';
+                details.style.color = '#4b5563';
+                const info = [];
+                if (piece.length) info.push(`${piece.length} mm`);
+                if (piece.radius) info.push(`Radius ${piece.radius} mm`);
+                if (piece.angle) info.push(`${piece.angle}°`);
+                details.textContent = info.join(' · ');
+                const button = document.createElement('button');
+                button.textContent = 'Add to board';
+                button.addEventListener('click', () => addPiece(piece.code));
+                item.appendChild(title);
+                item.appendChild(subtitle);
+                if (info.length) {
+                    item.appendChild(details);
+                }
+                if (piece.notes) {
+                    const notes = document.createElement('div');
+                    notes.textContent = piece.notes;
+                    notes.style.fontSize = '0.72rem';
+                    notes.style.color = '#6b7280';
+                    item.appendChild(notes);
+                }
+                item.appendChild(button);
+                libraryList.appendChild(item);
+            });
+    });
+};
+
+let svgPieces = null;
+let svgEndpoints = [];
+
+ensureIds();
+renderLibrary();
+renderBoard();
+updateInventory();
+Streamlit.setFrameHeight(document.querySelector('.planner-wrapper').offsetHeight + 24);
+</script>
+"""
+
+    return (
+        template
+        .replace("__BOARD__", board_json)
+        .replace("__POLYGON__", polygon_json)
+        .replace("__GRID__", grid_json)
+        .replace("__LIBRARY__", library_json)
+        .replace("__STATE__", state_json)
     )
 
 
-def _objective_controls() -> Tuple[List[str], List[float]]:
-    st.sidebar.header("Layout priorities")
-    objectives = st.sidebar.multiselect(
-        "Choose the goals that matter to you",
-        [
-            "Maximise track coverage",
-            "Maximise straight running",
-            "Include loops",
-            "Include spurs/sidings",
-            "Include fiddle yard",
-            "Minimise total track",
-            "Encourage complex operations",
-            "Prefer multiple loops",
-        ],
-        default=["Include loops"],
-    )
+st.title("Interactive Hornby OO Gauge Layout Planner")
+st.write(
+    "Design your layout directly on a board that matches your real-world space. Drag set-track sections from the library, align them on the board, and build spurs or loops with precise Hornby dimensions."
+)
 
-    allowed_radii = st.sidebar.multiselect(
-        "Allowed curve radii",
-        options=[371.0, 438.0, 505.0, 572.0],
-        format_func=lambda v: f"{v:.0f} mm",
-        default=[371.0, 438.0, 505.0, 572.0],
-    )
-    return objectives, allowed_radii
+board_config, polygon = _board_controls()
+grid_config = _grid_controls()
+
+if "layout_state" not in st.session_state:
+    st.session_state["layout_state"] = {"placements": []}
+
+def _describe_piece(piece: Optional[TrackPiece]) -> str:
+    if not piece:
+        return ""
+    bits: List[str] = []
+    if piece.length:
+        bits.append(f"{piece.length:.0f} mm")
+    if piece.radius:
+        bits.append(f"Radius {piece.radius:.0f} mm")
+    if piece.angle:
+        bits.append(f"{piece.angle:.1f}°")
+    return " · ".join(bits)
 
 
-def _render_plan(plan: LayoutPlan, board: BoardSpecification) -> None:
-    total_length = plan.total_length_mm() / 1000
-    straight_length = plan.straight_length_mm() / 1000
-    curve_length = plan.curve_length_mm() / 1000
-    breakdown = pd.DataFrame(
-        plan.piece_breakdown(), columns=["Catalogue", "Piece", "Quantity"]
-    )
+designer_html = _build_designer_html(
+    board_config,
+    polygon,
+    grid_config,
+    list(TRACK_LIBRARY.values()),
+    st.session_state.get("layout_state"),
+)
 
-    col1, col2 = st.columns([1, 1])
-    with col1:
-        st.subheader(plan.name)
-        st.write(plan.description)
-        st.metric("Total track length", f"{total_length:.2f} m")
-        st.metric("Straight sections", f"{straight_length:.2f} m")
-        st.metric("Curved sections", f"{curve_length:.2f} m")
-        st.write("**Features:** " + ", ".join(sorted(plan.features)))
-        if plan.notes:
-            st.markdown("**Notes:**")
-            for note in plan.notes:
-                st.markdown(f"- {note}")
-        st.dataframe(breakdown, hide_index=True, use_container_width=True)
+component_value = components.html(designer_html, height=640, scrolling=True, key="designer")
 
-    with col2:
-        geometry = plan.build_geometry()
-        width, height = board.bounding_box()
-        fig, ax = plt.subplots(figsize=(6, 4))
-        draw_geometry(geometry, ax)
-        half_width = width / 2
-        half_height = height / 2
-        ax.add_patch(
-            plt.Rectangle(
-                (-half_width, -half_height),
-                width,
-                height,
-                fill=False,
-                edgecolor="#555555",
-                linestyle=":",
-                linewidth=1.5,
-            )
+if component_value:
+    try:
+        new_state = json.loads(component_value)
+    except json.JSONDecodeError:
+        new_state = st.session_state.get("layout_state", {"placements": []})
+    else:
+        st.session_state["layout_state"] = new_state
+
+layout_state = st.session_state.get("layout_state", {"placements": []})
+placements = layout_state.get("placements", [])
+
+st.subheader("Layout summary")
+
+if placements:
+    total_length = total_run_length_mm(placements)
+    st.metric("Total run length", f"{total_length/1000:.2f} m")
+    counts = compute_piece_counts(placements)
+    summary_rows = []
+    for code, quantity in sorted(counts.items()):
+        piece = TRACK_LIBRARY.get(code)
+        summary_rows.append(
+            {
+                "Catalogue": code,
+                "Piece": piece.name if piece else "Unknown",
+                "Quantity": quantity,
+                "Details": _describe_piece(piece),
+            }
         )
-        ax.set_aspect("equal", adjustable="box")
-        ax.set_title("Track geometry preview")
-        ax.set_xlabel("mm")
-        ax.set_ylabel("mm")
-        ax.grid(True, linestyle=":", linewidth=0.5)
-        ax.set_xlim(-half_width - 200, half_width + 200)
-        ax.set_ylim(-half_height - 200, half_height + 200)
-        st.pyplot(fig, clear_figure=True)
-
-
-board = _board_controls()
-objectives, allowed_radii = _objective_controls()
-st.sidebar.header("Results")
-max_layouts = st.sidebar.slider("Number of layout options", min_value=1, max_value=6, value=3)
-
-st.info(describe_board(board))
-
-if allowed_radii:
-    allowed_radii_set = set(allowed_radii)
+    st.dataframe(summary_rows, hide_index=True, use_container_width=True)
 else:
-    allowed_radii_set = set()
+    st.info("Add track pieces to the board to see an inventory summary here.")
 
-generator = get_generator()
-layouts = generator.generate(board, set(objectives), allowed_radii_set, max_layouts=max_layouts)
 
-if not layouts:
-    st.warning("No layouts match the chosen board size and goals. Try expanding the allowed radii or relaxing priorities.")
-else:
-    for plan in layouts:
-        st.divider()
-        _render_plan(plan, board)
+st.caption(
+    "Tip: use the grid snap controls in the sidebar to match the spacing of your actual baseboard markings."
+)
+

--- a/planner.py
+++ b/planner.py
@@ -1,480 +1,152 @@
-"""Layout planning utilities for the Streamlit Hornby OO gauge planner app."""
+"""Data and helpers for the manual Hornby OO gauge planning interface."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import math
-
-import matplotlib.pyplot as plt
-import numpy as np
 
 
 @dataclass(frozen=True)
 class TrackPiece:
-    """Represents a single catalogue item from the Hornby track range."""
+    """Represents a catalogue item from the Hornby OO gauge set-track range."""
 
     code: str
     name: str
-    kind: str
-    length: float  # straight length or equivalent primary dimension in mm
-    angle: Optional[float] = None  # degrees for curves
-    radius: Optional[float] = None  # mm for curves
+    kind: str  # straight, curve, point, crossover, accessory
+    length: float  # for straights and nominal size for specials (mm)
+    angle: Optional[float] = None  # degrees for curves and turnouts
+    radius: Optional[float] = None  # mm for curves and curved turnouts
+    notes: Optional[str] = None
 
-    def arc_length(self) -> float:
-        """Return the length along the centreline for curved pieces."""
-        if self.kind != "curve" or self.angle is None or self.radius is None:
-            return 0.0
-        return 2 * math.pi * self.radius * (self.angle / 360.0)
+    def run_length(self) -> float:
+        """Return the travel distance along the centre-line for the piece."""
+
+        if self.kind == "curve" and self.radius and self.angle:
+            return 2 * math.pi * self.radius * (self.angle / 360.0)
+        return self.length
 
 
+# A curated library of the most common Hornby set-track sections with real-world dimensions.
+# The list purposely includes straight, curved, turnout and accessory pieces so the designer
+# can build loops, sidings, crossovers and branch lines without switching context.
 TRACK_LIBRARY: Dict[str, TrackPiece] = {
     "R600": TrackPiece("R600", "Standard Straight", "straight", 168.0),
     "R601": TrackPiece("R601", "Double Straight", "straight", 335.5),
-    "R603": TrackPiece("R603", "Half Straight", "straight", 67.0),
-    "R604": TrackPiece("R604", "Quarter Straight", "straight", 41.0),
-    "R606": TrackPiece("R606", "1st Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=371.0),
-    "R607": TrackPiece("R607", "2nd Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=438.0),
-    "R608": TrackPiece("R608", "3rd Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=505.0),
-    "R609": TrackPiece("R609", "4th Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=572.0),
-    "R610": TrackPiece("R610", "1st Radius Curve (22.5°)", "curve", length=0.0, angle=22.5, radius=371.0),
-    "R614": TrackPiece("R614", "90° Crossing", "special", 168.0),
-    "R8072": TrackPiece("R8072", "Left-hand Point", "point", 168.0),
-    "R8073": TrackPiece("R8073", "Right-hand Point", "point", 168.0),
+    "R602": TrackPiece("R602", "Short Straight", "straight", 112.0),
+    "R603": TrackPiece("R603", "Half Straight", "straight", 83.5),
+    "R604": TrackPiece("R604", "Quarter Straight", "straight", 41.75),
+    "R605": TrackPiece("R605", "Power Track", "straight", 168.0, notes="Insulated, power feed"),
+    "R606": TrackPiece("R606", "1st Radius Curve (45°)", "curve", 0.0, angle=45.0, radius=371.0),
+    "R607": TrackPiece("R607", "2nd Radius Curve (45°)", "curve", 0.0, angle=45.0, radius=438.0),
+    "R608": TrackPiece("R608", "3rd Radius Curve (45°)", "curve", 0.0, angle=45.0, radius=505.0),
+    "R609": TrackPiece("R609", "4th Radius Curve (45°)", "curve", 0.0, angle=45.0, radius=572.0),
+    "R610": TrackPiece("R610", "1st Radius Curve (22.5°)", "curve", 0.0, angle=22.5, radius=371.0),
+    "R611": TrackPiece("R611", "2nd Radius Curve (22.5°)", "curve", 0.0, angle=22.5, radius=438.0),
+    "R612": TrackPiece("R612", "3rd Radius Curve (22.5°)", "curve", 0.0, angle=22.5, radius=505.0),
+    "R613": TrackPiece("R613", "4th Radius Curve (22.5°)", "curve", 0.0, angle=22.5, radius=572.0),
+    "R614": TrackPiece("R614", "90° Crossing", "crossover", 168.0, angle=90.0),
+    "R615": TrackPiece("R615", "Double Curve (22.5°)", "curve", 0.0, angle=22.5, radius=438.0, notes="Superelevated"),
+    "R617": TrackPiece("R617", "Level Crossing", "accessory", 168.0),
+    "R618": TrackPiece("R618", "Buffer Stop", "accessory", 30.0),
+    "R620": TrackPiece("R620", "Half Curve (22.5°)", "curve", 0.0, angle=22.5, radius=371.0),
+    "R622": TrackPiece("R622", "Isolating Track", "straight", 168.0),
+    "R8072": TrackPiece("R8072", "Left-hand Point", "point", 168.0, angle=12.0, radius=438.0),
+    "R8073": TrackPiece("R8073", "Right-hand Point", "point", 168.0, angle=12.0, radius=438.0),
+    "R8074": TrackPiece("R8074", "Y Point", "point", 168.0, angle=12.0, radius=505.0),
+    "R8075": TrackPiece("R8075", "Curved Point Left", "point", 0.0, angle=22.5, radius=505.0),
+    "R8076": TrackPiece("R8076", "Curved Point Right", "point", 0.0, angle=22.5, radius=505.0),
+    "R8077": TrackPiece("R8077", "Diamond Crossing (12°)", "crossover", 185.0, angle=12.0),
+    "R8078": TrackPiece("R8078", "Double Slip", "crossover", 185.0, angle=12.0),
+    "R8079": TrackPiece("R8079", "Single Slip", "crossover", 185.0, angle=12.0),
+    "R8201": TrackPiece("R8201", "Power Track (DCC)", "straight", 168.0),
+    "R8202": TrackPiece("R8202", "Link Wire Track", "straight", 168.0),
+    "R8232": TrackPiece("R8232", "Diamond Crossing (R2)", "crossover", 168.0, angle=22.5),
+    "R8233": TrackPiece("R8233", "Double Track Level Crossing", "accessory", 168.0),
 }
 
 
-@dataclass
-class GeometryCommand:
-    """Instruction used to draw the preview of a layout."""
+def library_by_kind(kind: str) -> Sequence[TrackPiece]:
+    """Return all pieces matching the requested category."""
 
-    command: str
-    parameters: Tuple[float, ...]
+    return [piece for piece in TRACK_LIBRARY.values() if piece.kind == kind]
 
 
-@dataclass
-class LayoutPlan:
-    """Full definition of a layout proposal."""
+def track_library_as_rows() -> List[Tuple[str, str, str]]:
+    """Return the library as simple tuples for display tables."""
 
-    name: str
-    description: str
-    pieces: Dict[str, int]
-    footprint: Tuple[float, float]
-    features: Set[str]
-    radii_used: Set[float]
-    notes: List[str] = field(default_factory=list)
-    geometry_factory: Optional[Callable[["LayoutPlan"], List[GeometryCommand]]] = None
-
-    def total_length_mm(self) -> float:
-        total = 0.0
-        for code, count in self.pieces.items():
-            piece = TRACK_LIBRARY.get(code)
-            if not piece:
-                continue
-            if piece.kind == "curve":
-                total += piece.arc_length() * count
-            else:
-                total += piece.length * count
-        return total
-
-    def straight_length_mm(self) -> float:
-        total = 0.0
-        for code, count in self.pieces.items():
-            piece = TRACK_LIBRARY.get(code)
-            if not piece:
-                continue
-            if piece.kind in {"straight", "point", "special"}:
-                total += piece.length * count
-        return total
-
-    def curve_length_mm(self) -> float:
-        total = 0.0
-        for code, count in self.pieces.items():
-            piece = TRACK_LIBRARY.get(code)
-            if not piece:
-                continue
-            if piece.kind == "curve":
-                total += piece.arc_length() * count
-        return total
-
-    def piece_breakdown(self) -> List[Tuple[str, str, int]]:
-        breakdown: List[Tuple[str, str, int]] = []
-        for code, count in sorted(self.pieces.items()):
-            piece = TRACK_LIBRARY.get(code)
-            name = piece.name if piece else "Unknown"
-            breakdown.append((code, name, count))
-        return breakdown
-
-    def build_geometry(self) -> List[GeometryCommand]:
-        if self.geometry_factory is None:
-            return []
-        return self.geometry_factory(self)
-
-    def fits_within(self, width: float, height: float) -> bool:
-        footprint_width, footprint_height = self.footprint
-        return footprint_width <= width and footprint_height <= height
+    rows: List[Tuple[str, str, str]] = []
+    for code, piece in sorted(TRACK_LIBRARY.items()):
+        rows.append((code, piece.name, piece.kind.title()))
+    return rows
 
 
-@dataclass
-class BoardSpecification:
-    shape: str
-    width: float
-    height: float
-    polygon: Optional[List[Tuple[float, float]]] = None
+def compute_piece_counts(placements: Iterable[Dict[str, object]]) -> Dict[str, int]:
+    """Count how many instances of each catalogue item are placed."""
 
-    def bounding_box(self) -> Tuple[float, float]:
-        if self.shape == "custom" and self.polygon:
-            xs = [p[0] for p in self.polygon]
-            ys = [p[1] for p in self.polygon]
-            return max(xs) - min(xs), max(ys) - min(ys)
-        return self.width, self.height
+    totals: Dict[str, int] = {}
+    for placement in placements:
+        code = placement.get("code")
+        if not isinstance(code, str):
+            continue
+        totals[code] = totals.get(code, 0) + 1
+    return totals
 
 
-def _oval_points(radius: float, straight_total: float, offset: Tuple[float, float] = (0.0, 0.0), samples: int = 120) -> np.ndarray:
-    """Create a closed oval represented as (x, y) points."""
-    ox, oy = offset
-    half_straight = straight_total / 2.0
-    top = np.column_stack(
-        [np.linspace(half_straight, -half_straight, samples // 4), np.full(samples // 4, radius)]
-    )
-    bottom = np.column_stack(
-        [np.linspace(-half_straight, half_straight, samples // 4), np.full(samples // 4, -radius)]
-    )
-    theta_left = np.linspace(math.pi / 2, 3 * math.pi / 2, samples // 4)
-    left = np.column_stack(
-        [-half_straight + radius * np.cos(theta_left), radius * np.sin(theta_left)]
-    )
-    theta_right = np.linspace(-math.pi / 2, math.pi / 2, samples // 4)
-    right = np.column_stack(
-        [half_straight + radius * np.cos(theta_right), radius * np.sin(theta_right)]
-    )
-    points = np.vstack([top, left, bottom, right, top[:1]])
-    points[:, 0] += ox
-    points[:, 1] += oy
-    return points
+def total_run_length_mm(placements: Iterable[Dict[str, object]]) -> float:
+    """Total run length of the layout assembled so far."""
+
+    total = 0.0
+    for placement in placements:
+        code = placement.get("code")
+        if not isinstance(code, str):
+            continue
+        piece = TRACK_LIBRARY.get(code)
+        if not piece:
+            continue
+        total += piece.run_length()
+    return total
 
 
-def draw_geometry(commands: Sequence[GeometryCommand], ax: plt.Axes) -> None:
-    for command in commands:
-        if command.command == "oval":
-            radius, straight_total, ox, oy = command.parameters
-            pts = _oval_points(radius, straight_total, (ox, oy))
-            ax.plot(pts[:, 0], pts[:, 1], color="#1f77b4", linewidth=2)
-        elif command.command == "line":
-            x1, y1, x2, y2 = command.parameters
-            ax.plot([x1, x2], [y1, y2], color="#1f77b4", linewidth=2)
-        elif command.command == "siding":
-            x1, y1, x2, y2 = command.parameters
-            ax.plot([x1, x2], [y1, y2], color="#ff7f0e", linewidth=2, linestyle="--")
-        elif command.command == "marker":
-            x, y = command.parameters
-            ax.scatter([x], [y], s=20, color="#2ca02c")
+def board_polygon_for_rectangle(width: float, height: float) -> List[Tuple[float, float]]:
+    """Create a polygon that outlines a rectangular board."""
+
+    return [(0.0, 0.0), (width, 0.0), (width, height), (0.0, height)]
 
 
-class LayoutGenerator:
-    """Selects layout templates that meet the user's brief."""
+def board_polygon_for_l_shape(
+    long_leg: float,
+    short_leg: float,
+    depth: float,
+) -> List[Tuple[float, float]]:
+    """Return the polygon for an L-shaped board."""
 
-    def __init__(self, templates: Iterable[LayoutPlan]):
-        self.templates = list(templates)
-
-    def generate(
-        self,
-        board: BoardSpecification,
-        objectives: Set[str],
-        allowed_radii: Set[float],
-        max_layouts: int = 5,
-    ) -> List[LayoutPlan]:
-        width, height = board.bounding_box()
-        required_features = set()
-        if "Include loops" in objectives:
-            required_features.add("loop")
-        if "Include spurs/sidings" in objectives:
-            required_features.add("spur")
-        if "Include fiddle yard" in objectives:
-            required_features.add("fiddle_yard")
-
-        candidates: List[Tuple[float, LayoutPlan]] = []
-        for template in self.templates:
-            if not template.fits_within(width, height):
-                continue
-            if required_features and not required_features.issubset(template.features):
-                continue
-            if allowed_radii and not template.radii_used.issubset(allowed_radii):
-                continue
-
-            score = self._score(template, objectives)
-            candidates.append((score, template))
-
-        reverse = True
-        if "Minimise total track" in objectives and "Maximise track coverage" not in objectives:
-            reverse = False
-
-        candidates.sort(key=lambda item: item[0], reverse=reverse)
-        return [tpl for _, tpl in candidates[:max_layouts]]
-
-    def _score(self, template: LayoutPlan, objectives: Set[str]) -> float:
-        total = template.total_length_mm()
-        straights = template.straight_length_mm()
-        score = 0.0
-        if not objectives:
-            score = total
-        if "Maximise track coverage" in objectives:
-            score += total
-        if "Maximise straight running" in objectives:
-            score += straights * 1.25
-        if "Minimise total track" in objectives:
-            score -= total
-        if "Encourage complex operations" in objectives and "fiddle_yard" in template.features:
-            score += 500.0
-        if "Encourage complex operations" in objectives and "spur" in template.features:
-            score += 250.0
-        if "Prefer multiple loops" in objectives and "multi_loop" in template.features:
-            score += 500.0
-        return score
+    return [
+        (0.0, 0.0),
+        (long_leg, 0.0),
+        (long_leg, depth),
+        (depth, depth),
+        (depth, short_leg),
+        (0.0, short_leg),
+    ]
 
 
-CLEARANCE = 120.0  # mm of margin around templates to give realistic space
+def normalise_polygon(points: Sequence[Tuple[float, float]]) -> List[Tuple[float, float]]:
+    """Translate a polygon so the minimum coordinate starts at the origin."""
+
+    if not points:
+        return []
+    min_x = min(p[0] for p in points)
+    min_y = min(p[1] for p in points)
+    return [(x - min_x, y - min_y) for x, y in points]
 
 
-def _oval_geometry_factory(radius: float, straight_count: int, straight_code: str) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    piece = TRACK_LIBRARY[straight_code]
-    straight_total = piece.length * (straight_count / 2)
+def polygon_bounds(points: Sequence[Tuple[float, float]]) -> Tuple[float, float]:
+    """Return the width and height of a polygon's bounding box."""
 
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        return [GeometryCommand("oval", (radius, straight_total, 0.0, 0.0))]
+    if not points:
+        return 0.0, 0.0
+    xs = [p[0] for p in points]
+    ys = [p[1] for p in points]
+    return max(xs) - min(xs), max(ys) - min(ys)
 
-    return factory
-
-
-def _oval_with_siding_geometry_factory(radius: float, straight_code: str, siding_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    piece = TRACK_LIBRARY[straight_code]
-    straight_total = piece.length * 2
-
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        commands = [GeometryCommand("oval", (radius, straight_total, 0.0, 0.0))]
-        commands.append(
-            GeometryCommand(
-                "siding",
-                (-straight_total / 2, radius + 60.0, -straight_total / 2 - siding_length, radius + 60.0),
-            )
-        )
-        commands.append(
-            GeometryCommand(
-                "siding",
-                (-straight_total / 2 + 30.0, radius + 60.0, -straight_total / 2 + 30.0, radius + 120.0),
-            )
-        )
-        return commands
-
-    return factory
-
-
-def _double_oval_geometry_factory(inner_radius: float, outer_radius: float, straight_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    half = straight_length
-
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        commands = [
-            GeometryCommand("oval", (outer_radius, half * 2, 0.0, 0.0)),
-            GeometryCommand("oval", (inner_radius, (half - 60.0) * 2, 0.0, 0.0)),
-            GeometryCommand("line", (-half - inner_radius, 0.0, -half - inner_radius, -200.0)),
-            GeometryCommand("line", (-half - inner_radius, -200.0, -half + inner_radius, -200.0)),
-        ]
-        return commands
-
-    return factory
-
-
-def _figure_eight_geometry_factory(radius: float, straight_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    half = straight_length / 2
-
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        left_center = (-half, 0.0)
-        right_center = (half, 0.0)
-        commands = [GeometryCommand("line", (left_center[0], radius, right_center[0], -radius))]
-        commands.append(GeometryCommand("oval", (radius, straight_length, *left_center)))
-        commands.append(GeometryCommand("oval", (radius, straight_length, *right_center)))
-        return commands
-
-    return factory
-
-
-def _fiddle_yard_geometry_factory(main_length: float, sidings: int, spacing: float = 70.0) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        commands = [GeometryCommand("line", (-main_length / 2, 0.0, main_length / 2, 0.0))]
-        for i in range(1, sidings + 1):
-            offset = i * spacing
-            commands.append(GeometryCommand("siding", (-main_length / 2 + 200.0, offset, main_length / 2, offset)))
-        return commands
-
-    return factory
-
-
-def default_templates() -> List[LayoutPlan]:
-    templates: List[LayoutPlan] = []
-
-    # Compact oval (1st radius)
-    radius = TRACK_LIBRARY["R606"].radius or 0.0
-    straight_piece = TRACK_LIBRARY["R600"].length
-    straight_total = straight_piece * 2
-    footprint = (2 * radius + straight_total + CLEARANCE, 2 * radius + CLEARANCE)
-    templates.append(
-        LayoutPlan(
-            name="Compact Continuous Oval",
-            description="A simple 1st radius oval ideal for very small boards and continuous running.",
-            pieces={"R606": 8, "R600": 4},
-            footprint=footprint,
-            features={"loop", "compact"},
-            radii_used={radius},
-            notes=["Add power clips to any straight for track power."],
-            geometry_factory=_oval_geometry_factory(radius, 4, "R600"),
-        )
-    )
-
-    # Standard oval with passing loop
-    radius = TRACK_LIBRARY["R607"].radius or 0.0
-    straight_length = TRACK_LIBRARY["R600"].length
-    straight_total = straight_length * 2
-    footprint = (2 * radius + straight_total + CLEARANCE + 180.0, 2 * radius + CLEARANCE + 140.0)
-    templates.append(
-        LayoutPlan(
-            name="Passing Loop Oval",
-            description="2nd radius oval with a passing loop for two-train operation or station stops.",
-            pieces={
-                "R607": 8,
-                "R600": 6,
-                "R603": 2,
-                "R8072": 1,
-                "R8073": 1,
-            },
-            footprint=footprint,
-            features={"loop", "spur"},
-            radii_used={radius},
-            notes=["Points form a loop on the top straight allowing trains to pass."],
-            geometry_factory=_oval_with_siding_geometry_factory(radius, "R600", 400.0),
-        )
-    )
-
-    # Double track oval
-    inner_radius = TRACK_LIBRARY["R607"].radius or 0.0
-    outer_radius = TRACK_LIBRARY["R608"].radius or 0.0
-    straight_length = TRACK_LIBRARY["R600"].length * 2
-    footprint = (2 * outer_radius + straight_length + CLEARANCE + 160.0, 2 * outer_radius + CLEARANCE + 120.0)
-    templates.append(
-        LayoutPlan(
-            name="Twin Track Mainline",
-            description="Paired 2nd and 3rd radius loops for continuous two-train running with a crossover.",
-            pieces={
-                "R608": 8,
-                "R607": 8,
-                "R600": 8,
-                "R8072": 2,
-                "R8073": 2,
-            },
-            footprint=footprint,
-            features={"loop", "multi_loop", "max_track"},
-            radii_used={inner_radius, outer_radius},
-            notes=["Use opposing points as a scissors crossover between the loops."],
-            geometry_factory=_double_oval_geometry_factory(inner_radius, outer_radius, straight_length / 2),
-        )
-    )
-
-    # Large oval with fiddle yard
-    radius = TRACK_LIBRARY["R609"].radius or 0.0
-    straight_length = TRACK_LIBRARY["R601"].length * 2
-    footprint = (2 * radius + straight_length + CLEARANCE + 420.0, 2 * radius + CLEARANCE + 200.0)
-    templates.append(
-        LayoutPlan(
-            name="Mainline with Fiddle Yard",
-            description="4th radius oval with extended straights feeding a three-road fiddle yard.",
-            pieces={
-                "R609": 8,
-                "R601": 4,
-                "R8072": 3,
-                "R8073": 3,
-                "R600": 6,
-            },
-            footprint=footprint,
-            features={"loop", "fiddle_yard", "spur", "max_track"},
-            radii_used={radius},
-            notes=["Three sidings can store full-length trains ready to enter the mainline."],
-            geometry_factory=_fiddle_yard_geometry_factory(straight_length + 2 * radius, sidings=3),
-        )
-    )
-
-    # End-to-end with fiddle yard
-    main_length = 2400.0
-    footprint = (main_length + CLEARANCE, 600.0 + CLEARANCE)
-    templates.append(
-        LayoutPlan(
-            name="End-to-End Terminus",
-            description="End-to-end layout with a three road fiddle yard and long platform straight.",
-            pieces={
-                "R601": 8,
-                "R600": 6,
-                "R603": 4,
-                "R8072": 3,
-                "R8073": 3,
-            },
-            footprint=footprint,
-            features={"fiddle_yard", "spur", "terminus"},
-            radii_used=set(),
-            notes=["Ideal for shunting and timetable operations without requiring continuous running."],
-            geometry_factory=_fiddle_yard_geometry_factory(main_length, sidings=3),
-        )
-    )
-
-    # Compact shunting puzzle
-    footprint = (1600.0 + CLEARANCE, 600.0 + CLEARANCE)
-    templates.append(
-        LayoutPlan(
-            name="Shunting Puzzle Yard",
-            description="A Inglenook-inspired yard using set-track pieces for switching challenges.",
-            pieces={
-                "R600": 10,
-                "R603": 6,
-                "R604": 4,
-                "R8072": 2,
-                "R8073": 1,
-            },
-            footprint=footprint,
-            features={"spur", "operations"},
-            radii_used=set(),
-            notes=["Lengths suit three wagon trains in the longest siding and two wagons elsewhere."],
-            geometry_factory=_fiddle_yard_geometry_factory(1200.0, sidings=2),
-        )
-    )
-
-    # Figure eight continuous run
-    radius = TRACK_LIBRARY["R607"].radius or 0.0
-    straight_length = TRACK_LIBRARY["R600"].length * 2
-    footprint = (straight_length * 2 + 2 * radius + CLEARANCE, 2 * radius + straight_length + CLEARANCE)
-    templates.append(
-        LayoutPlan(
-            name="Figure Eight with Crossing",
-            description="Continuous run with grade-level crossover for visual interest and reversing loops.",
-            pieces={
-                "R607": 16,
-                "R600": 4,
-                "R614": 1,
-            },
-            footprint=footprint,
-            features={"loop", "crossover", "max_track"},
-            radii_used={radius},
-            notes=["Consider using power districts to avoid shorts through the crossing."],
-            geometry_factory=_figure_eight_geometry_factory(radius, straight_length),
-        )
-    )
-
-    return templates
-
-
-def describe_board(board: BoardSpecification) -> str:
-    width, height = board.bounding_box()
-    dims = f"{width/1000:.2f} m x {height/1000:.2f} m"
-    if board.shape == "rectangle":
-        return f"Rectangular board {dims}"
-    if board.shape == "l-shape":
-        return f"L-shaped board envelope {dims}"
-    if board.shape == "custom":
-        return f"Custom board bounding box {dims}"
-    return dims

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-matplotlib==3.8.4
-numpy==1.26.4
-pandas==2.2.2
 streamlit==1.34.0


### PR DESCRIPTION
## Summary
- replace the auto-generated layout workflow with an interactive SVG planner that lets users drag, rotate, flip, and snap Hornby track pieces on a board matching their dimensions
- expand the Hornby track library to include straights, curves, turnouts, crossings, and accessories with accurate radii and lengths for manual planning
- surface live inventory and run-length summaries driven by the placed pieces returned from the embedded designer

## Testing
- python -m compileall app.py planner.py

------
https://chatgpt.com/codex/tasks/task_e_68dee2ed51c883249bd0a0cd34f0d5bf