### PR TITLE
Enable curve-aware snapping for Hornby track sections

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,45 +1,67 @@
-from typing import List, Tuple
+from __future__ import annotations
+
+import json
+from string import Template
+from typing import Dict, List, Tuple
 
 import streamlit as st
+import streamlit.components.v1 as components
 
 from planner import (
     BoardSpecification,
-    LayoutGenerator,
-    LayoutPlan,
     describe_board,
-    default_templates,
-    render_geometry_svg,
+    hornby_track_library,
+    inventory_from_placements,
+    total_run_length_mm,
 )
 
 
 st.set_page_config(page_title="Hornby OO Layout Planner", layout="wide")
 st.title("Hornby OO Gauge Layout Planner")
 st.write(
-    """Design OO gauge train set plans by choosing a baseboard size and the features you would like in your layout.\n"
-    "The planner uses real-world Hornby set-track dimensions to recommend track plans that fit within your available space."""
+    """Lay out your own Hornby OO gauge plan directly on the baseboard outline.\n"
+    "Define the board you are building, drag track from the library, rotate or flip pieces,"
+    " and snap them together while the planner keeps an eye on inventory and total run length."""
 )
 
 
-@st.cache_resource
-def get_generator() -> LayoutGenerator:
-    return LayoutGenerator(default_templates())
-
-
 def _board_controls() -> BoardSpecification:
-    st.sidebar.header("Board")
-    shape = st.sidebar.selectbox("Board shape", ["Rectangle", "L-Shape", "Custom polygon"], index=0)
+    st.sidebar.header("Board outline")
+    shape = st.sidebar.selectbox(
+        "Board shape",
+        ["Rectangle", "L-Shape", "Custom polygon"],
+        index=0,
+    )
 
     if shape == "Rectangle":
         width = st.sidebar.number_input("Width (mm)", min_value=600.0, value=1800.0, step=50.0)
         height = st.sidebar.number_input("Depth (mm)", min_value=450.0, value=1200.0, step=50.0)
-        return BoardSpecification(shape="rectangle", width=width, height=height)
+        polygon = [
+            (0.0, 0.0),
+            (width, 0.0),
+            (width, height),
+            (0.0, height),
+        ]
+        return BoardSpecification(shape="rectangle", width=width, height=height, polygon=polygon)
 
     if shape == "L-Shape":
         long_leg = st.sidebar.number_input("Long leg length (mm)", min_value=1000.0, value=2400.0, step=50.0)
         short_leg = st.sidebar.number_input("Short leg length (mm)", min_value=800.0, value=1500.0, step=50.0)
-        width = st.sidebar.number_input("Overall width (mm)", min_value=600.0, value=900.0, step=25.0)
-        polygon = [(0.0, 0.0), (long_leg, 0.0), (long_leg, width), (width, width), (width, short_leg), (0.0, short_leg)]
-        return BoardSpecification(shape="l-shape", width=long_leg, height=short_leg, polygon=polygon)
+        shelf_width = st.sidebar.number_input("Shelf width (mm)", min_value=450.0, value=900.0, step=25.0)
+        polygon = [
+            (0.0, 0.0),
+            (long_leg, 0.0),
+            (long_leg, shelf_width),
+            (shelf_width, shelf_width),
+            (shelf_width, short_leg),
+            (0.0, short_leg),
+        ]
+        return BoardSpecification(
+            shape="l-shape",
+            width=long_leg,
+            height=short_leg,
+            polygon=polygon,
+        )
 
     st.sidebar.markdown(
         "Enter the corner points of your board outline in millimetres. "
@@ -56,7 +78,7 @@ def _board_controls() -> BoardSpecification:
         "Corner points",
         value=default_text,
         key="custom_polygon",
-        height=120,
+        height=160,
     )
     polygon: List[Tuple[float, float]] = []
     invalid_lines = 0
@@ -78,88 +100,834 @@ def _board_controls() -> BoardSpecification:
         st.sidebar.warning(
             f"Skipped {invalid_lines} line{'s' if invalid_lines != 1 else ''} with invalid coordinates."
         )
-    return BoardSpecification(
-        shape="custom",
-        width=max(p[0] for p in polygon) if polygon else 0.0,
-        height=max(p[1] for p in polygon) if polygon else 0.0,
-        polygon=polygon,
-    )
+    width = max((p[0] for p in polygon), default=0.0)
+    height = max((p[1] for p in polygon), default=0.0)
+    return BoardSpecification(shape="custom", width=width, height=height, polygon=polygon)
 
 
-def _objective_controls() -> Tuple[List[str], List[float]]:
-    st.sidebar.header("Layout priorities")
-    objectives = st.sidebar.multiselect(
-        "Choose the goals that matter to you",
-        [
-            "Maximise track coverage",
-            "Maximise straight running",
-            "Include loops",
-            "Include spurs/sidings",
-            "Include fiddle yard",
-            "Minimise total track",
-            "Encourage complex operations",
-            "Prefer multiple loops",
-        ],
-        default=["Include loops"],
-    )
-
-    allowed_radii = st.sidebar.multiselect(
-        "Allowed curve radii",
-        options=[371.0, 438.0, 505.0, 572.0],
-        format_func=lambda v: f"{v:.0f} mm",
-        default=[371.0, 438.0, 505.0, 572.0],
-    )
-    return objectives, allowed_radii
-
-
-def _render_plan(plan: LayoutPlan, board: BoardSpecification) -> None:
-    total_length = plan.total_length_mm() / 1000
-    straight_length = plan.straight_length_mm() / 1000
-    curve_length = plan.curve_length_mm() / 1000
-    breakdown_rows = [
-        {"Catalogue": code, "Piece": name, "Quantity": count}
-        for code, name, count in plan.piece_breakdown()
+def _designer(board: BoardSpecification, placements: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    library = hornby_track_library()
+    board_polygon = board.polygon_points()
+    board_payload = {
+        "polygon": board_polygon,
+        "description": describe_board(board),
+    }
+    track_payload = [
+        {
+            "code": piece.code,
+            "name": piece.name,
+            "kind": piece.kind,
+            "length": piece.length,
+            "angle": piece.angle,
+            "radius": piece.radius,
+            "displayLength": piece.arc_length() if piece.kind == "curve" else piece.length,
+        }
+        for piece in library.values()
     ]
 
-    col1, col2 = st.columns([1, 1])
-    with col1:
-        st.subheader(plan.name)
-        st.write(plan.description)
-        st.metric("Total track length", f"{total_length:.2f} m")
-        st.metric("Straight sections", f"{straight_length:.2f} m")
-        st.metric("Curved sections", f"{curve_length:.2f} m")
-        st.write("**Features:** " + ", ".join(sorted(plan.features)))
-        if plan.notes:
-            st.markdown("**Notes:**")
-            for note in plan.notes:
-                st.markdown(f"- {note}")
-        st.dataframe(breakdown_rows, hide_index=True, use_container_width=True)
+    library_cards = []
+    for item in track_payload:
+        card = (
+            "<div class=\"library-item\">"
+            f"<strong>{item['code']}</strong><br/>"
+            f"<span>{item['name']}</span><br/>"
+            f"<small>{item['kind'].title()} · {item['displayLength']:.0f} mm</small>"
+            f"<button data-code=\"{item['code']}\" class=\"add-piece\">Add to board</button>"
+            "</div>"
+        )
+        library_cards.append(card)
 
-    with col2:
-        geometry = plan.build_geometry()
-        width, height = board.bounding_box()
-        svg = render_geometry_svg(geometry, width, height)
-        st.markdown(svg, unsafe_allow_html=True)
+    html_template = Template(
+        """
+    <style>
+    .designer-wrapper {
+        display: flex;
+        gap: 1rem;
+        font-family: 'Source Sans Pro', sans-serif;
+    }
+    .track-library {
+        width: 260px;
+        max-height: 640px;
+        overflow-y: auto;
+        border: 1px solid #d0d0d0;
+        border-radius: 0.5rem;
+        padding: 0.75rem;
+        background: #f8f9fb;
+    }
+    .track-library h3 {
+        margin-top: 0;
+        font-size: 1.1rem;
+    }
+    .library-item {
+        border: 1px solid #d7d7d7;
+        border-radius: 0.4rem;
+        padding: 0.5rem;
+        margin-bottom: 0.5rem;
+        background: #ffffff;
+    }
+    .library-item button {
+        margin-top: 0.4rem;
+        width: 100%;
+        padding: 0.35rem 0.5rem;
+        border-radius: 0.3rem;
+        border: 1px solid #1f77b4;
+        background: #1f77b4;
+        color: white;
+        cursor: pointer;
+    }
+    .board-canvas {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+    }
+    #boardCanvas {
+        width: 100%;
+        height: 560px;
+        border: 2px solid #d0d0d0;
+        border-radius: 0.5rem;
+        background: #ffffff;
+        touch-action: none;
+    }
+    .piece-controls {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        align-items: center;
+    }
+    .piece-controls button {
+        padding: 0.4rem 0.75rem;
+        border-radius: 0.4rem;
+        border: 1px solid #666666;
+        background: #f2f2f2;
+        cursor: pointer;
+    }
+    .piece-controls button.primary {
+        border-color: #1f77b4;
+        background: #1f77b4;
+        color: white;
+    }
+    .piece-controls label {
+        font-size: 0.85rem;
+        display: flex;
+        align-items: center;
+        gap: 0.3rem;
+        background: #ffffff;
+        border: 1px dashed #8fa1c7;
+        padding: 0.35rem 0.5rem;
+        border-radius: 0.35rem;
+    }
+    .piece-controls label input {
+        accent-color: #1f77b4;
+    }
+    .piece-controls span {
+        font-weight: 600;
+    }
+    .hint {
+        font-size: 0.85rem;
+        color: #555555;
+    }
+    </style>
+    <div class="designer-wrapper">
+        <div class="track-library">
+            <h3>Hornby Set-Track</h3>
+            <p class="hint">Click "Add" to drop a piece onto the board. Drag pieces on the canvas and use the controls to rotate, flip, nudge or snap.</p>
+            $library_cards
+        </div>
+        <div class="board-canvas">
+            <canvas id="boardCanvas"></canvas>
+            <div class="piece-controls">
+                <span id="selectionLabel">No piece selected</span>
+                <button id="rotateLeft">⟲ Rotate -15°</button>
+                <button id="rotateRight">⟳ Rotate +15°</button>
+                <button id="flipPiece">Flip</button>
+                <button id="nudgeUp">▲ Nudge</button>
+                <button id="nudgeDown">▼ Nudge</button>
+                <button id="nudgeLeft">◀ Nudge</button>
+                <button id="nudgeRight">▶ Nudge</button>
+                <button id="snapConnect" class="primary">Snap to piece</button>
+                <button id="snapGrid">Snap to 10 mm</button>
+                <button id="deletePiece">🗑 Remove</button>
+                <label class="section-toggle"><input type="checkbox" id="sectionMode" /> Move whole section</label>
+            </div>
+            <p class="hint">Tip: hold and drag pieces directly on the board. Connection points appear as green markers to help with alignment.</p>
+        </div>
+    </div>
+    <script>
+    const boardData = $board_json;
+    const trackLibrary = $track_json;
+    const initialPlacements = $placements_json;
+    const libraryByCode = Object.fromEntries(trackLibrary.map(item => [item.code, item]));
+    const placements = initialPlacements.map((item, idx) => {
+        const generatedId = item.id || ('placement-' + idx);
+        return {
+            id: generatedId,
+            code: item.code,
+            x: typeof item.x === 'number' ? item.x : 0,
+            y: typeof item.y === 'number' ? item.y : 0,
+            rotation: typeof item.rotation === 'number' ? item.rotation : 0,
+            flipped: Boolean(item.flipped),
+            sectionId: item.sectionId || generatedId,
+        };
+    });
+    let nextId = placements.length;
+    let selectedId = placements.length ? placements[placements.length - 1].id : null;
+    let applySection = false;
+    let draggingSection = false;
+    let sectionOriginals = [];
+    let sectionOriginalMap = {};
+    let pointerStart = null;
+
+    const canvas = document.getElementById('boardCanvas');
+    const ctx = canvas.getContext('2d');
+
+    const polygon = boardData.polygon && boardData.polygon.length ? boardData.polygon : [
+        [0, 0], [2400, 0], [2400, 1200], [0, 1200]
+    ];
+    const xs = polygon.map(pt => pt[0]);
+    const ys = polygon.map(pt => pt[1]);
+    const minX = Math.min(...xs);
+    const maxX = Math.max(...xs);
+    const minY = Math.min(...ys);
+    const maxY = Math.max(...ys);
+    const widthMm = Math.max(maxX - minX, 1);
+    const heightMm = Math.max(maxY - minY, 1);
+    const padding = 60;
+
+    function resizeCanvas() {
+        const rect = canvas.getBoundingClientRect();
+        canvas.width = rect.width;
+        canvas.height = rect.height;
+        draw();
+        requestFrameHeight();
+    }
+
+    function mmToCanvas(x, y) {
+        const scale = Math.min((canvas.width - padding * 2) / widthMm, (canvas.height - padding * 2) / heightMm);
+        const cx = (x - minX) * scale + padding;
+        const cy = canvas.height - ((y - minY) * scale + padding);
+        return { x: cx, y: cy, scale };
+    }
+
+    function canvasToMm(x, y) {
+        const scale = Math.min((canvas.width - padding * 2) / widthMm, (canvas.height - padding * 2) / heightMm);
+        const mmX = (x - padding) / scale + minX;
+        const mmY = ((canvas.height - y) - padding) / scale + minY;
+        return { x: mmX, y: mmY, scale };
+    }
+
+    function degToRad(deg) {
+        return (deg * Math.PI) / 180;
+    }
+
+    function radToDeg(rad) {
+        return (rad * 180) / Math.PI;
+    }
+
+    function normaliseDeg(deg) {
+        let result = deg % 360;
+        if (result < 0) {
+            result += 360;
+        }
+        return result;
+    }
+
+    function normaliseRad(rad) {
+        let result = rad % (2 * Math.PI);
+        if (result < -Math.PI) {
+            result += 2 * Math.PI;
+        }
+        if (result > Math.PI) {
+            result -= 2 * Math.PI;
+        }
+        return result;
+    }
+
+    function rotatePoint(point, angleRad) {
+        const cos = Math.cos(angleRad);
+        const sin = Math.sin(angleRad);
+        return {
+            x: cos * point.x - sin * point.y,
+            y: sin * point.x + cos * point.y,
+        };
+    }
+
+    function clone(obj) {
+        return JSON.parse(JSON.stringify(obj));
+    }
+
+    function getLocalEndpoints(piece) {
+        if (!piece) {
+            return [];
+        }
+        if (piece.kind === 'curve' && piece.radius && piece.angle) {
+            const halfTheta = degToRad(piece.angle) / 2;
+            const startAngle = halfTheta;
+            const endAngle = -halfTheta;
+            return [
+                {
+                    localPoint: {
+                        x: piece.radius * Math.cos(startAngle),
+                        y: piece.radius * Math.sin(startAngle),
+                    },
+                    localTangentAngle: Math.atan2(-Math.cos(startAngle), Math.sin(startAngle)),
+                },
+                {
+                    localPoint: {
+                        x: piece.radius * Math.cos(endAngle),
+                        y: piece.radius * Math.sin(endAngle),
+                    },
+                    localTangentAngle: Math.atan2(-Math.cos(endAngle), Math.sin(endAngle)),
+                },
+            ];
+        }
+        const length = piece.displayLength || piece.length || 0;
+        return [
+            {
+                localPoint: { x: length / 2, y: 0 },
+                localTangentAngle: 0,
+            },
+            {
+                localPoint: { x: -length / 2, y: 0 },
+                localTangentAngle: Math.PI,
+            },
+        ];
+    }
+
+    function applyFlipToEndpoint(endpoint, flipped) {
+        if (!flipped) {
+            return clone(endpoint);
+        }
+        return {
+            localPoint: {
+                x: endpoint.localPoint.x,
+                y: -endpoint.localPoint.y,
+            },
+            localTangentAngle: -endpoint.localTangentAngle,
+        };
+    }
+
+    function getPlacementLocalEndpoints(placement) {
+        const piece = libraryByCode[placement.code];
+        if (!piece) {
+            return [];
+        }
+        const endpoints = getLocalEndpoints(piece);
+        return endpoints.map(ep => applyFlipToEndpoint(ep, placement.flipped));
+    }
+
+    function getPlacementWorldEndpoints(placement) {
+        const rotationRad = degToRad(placement.rotation || 0);
+        const endpoints = getPlacementLocalEndpoints(placement);
+        return endpoints.map(ep => {
+            const rotated = rotatePoint(ep.localPoint, rotationRad);
+            const point = {
+                x: placement.x + rotated.x,
+                y: placement.y + rotated.y,
+            };
+            const tangentAngle = normaliseRad(ep.localTangentAngle + rotationRad);
+            return {
+                point,
+                tangentAngle,
+            };
+        });
+    }
+
+    function drawBoard() {
+        if (!polygon.length) {
+            return;
+        }
+        ctx.save();
+        ctx.beginPath();
+        polygon.forEach((pt, idx) => {
+            const { x, y } = mmToCanvas(pt[0], pt[1]);
+            if (idx === 0) {
+                ctx.moveTo(x, y);
+            } else {
+                ctx.lineTo(x, y);
+            }
+        });
+        ctx.closePath();
+        ctx.fillStyle = '#f5f7ff';
+        ctx.fill();
+        ctx.lineWidth = 2;
+        ctx.strokeStyle = '#5a6aa1';
+        ctx.stroke();
+        ctx.restore();
+    }
+
+    function drawPlacements() {
+        placements.forEach(placement => {
+            const piece = libraryByCode[placement.code];
+            if (!piece) { return; }
+            const { x, y, scale } = mmToCanvas(placement.x, placement.y);
+            const rotation = (placement.rotation || 0) * Math.PI / 180;
+            const selected = placement.id === selectedId;
+            const displayLength = piece.displayLength || piece.length || 0;
+            const trackWidth = 32 * scale;
+            ctx.save();
+            ctx.translate(x, y);
+            ctx.rotate(-rotation);
+            if (piece.kind === 'curve' && piece.radius && piece.angle) {
+                const radiusPx = piece.radius * scale;
+                const startAngle = piece.angle * Math.PI / 180 / 2;
+                ctx.beginPath();
+                ctx.strokeStyle = selected ? '#d62728' : '#1f77b4';
+                ctx.lineWidth = 6;
+                ctx.arc(0, 0, radiusPx, startAngle, -startAngle, true);
+                ctx.stroke();
+            } else {
+                const halfLength = (displayLength / 2) * scale;
+                ctx.beginPath();
+                ctx.fillStyle = selected ? '#ffe5d1' : '#dce9ff';
+                ctx.strokeStyle = selected ? '#d62728' : '#1f77b4';
+                ctx.lineWidth = 2;
+                ctx.rect(-halfLength, -trackWidth / 2, halfLength * 2, trackWidth);
+                ctx.fill();
+                ctx.stroke();
+            }
+            ctx.restore();
+
+            // Connection points
+            const points = connectionPoints(placement);
+            points.forEach(pt => {
+                const { x: px, y: py } = mmToCanvas(pt.x, pt.y);
+                ctx.beginPath();
+                ctx.fillStyle = '#2ca02c';
+                ctx.arc(px, py, 6, 0, 2 * Math.PI);
+                ctx.fill();
+            });
+        });
+    }
+
+    function draw() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        drawBoard();
+        drawPlacements();
+    }
+
+    function connectionPoints(placement) {
+        return getPlacementWorldEndpoints(placement).map(ep => ep.point);
+    }
+
+    function emitState() {
+        const payload = {
+            placements: placements.map(item => ({
+                id: item.id,
+                code: item.code,
+                x: item.x,
+                y: item.y,
+                rotation: item.rotation,
+                flipped: item.flipped,
+                sectionId: item.sectionId,
+            })),
+            board: boardData,
+        };
+        window.parent.postMessage({
+            isStreamlitMessage: true,
+            type: "streamlit:setComponentValue",
+            value: JSON.stringify(payload),
+        }, "*");
+    }
+
+    function getSectionMembers(sectionId) {
+        return placements.filter(item => item.sectionId === sectionId);
+    }
+
+    function rotateSection(sectionId, pivotPlacement, deltaDeg) {
+        const deltaRad = degToRad(deltaDeg);
+        const cos = Math.cos(deltaRad);
+        const sin = Math.sin(deltaRad);
+        const pivotX = pivotPlacement.x;
+        const pivotY = pivotPlacement.y;
+        const members = getSectionMembers(sectionId);
+        members.forEach(member => {
+            const relX = member.x - pivotX;
+            const relY = member.y - pivotY;
+            const rotatedX = pivotX + cos * relX - sin * relY;
+            const rotatedY = pivotY + sin * relX + cos * relY;
+            member.x = rotatedX;
+            member.y = rotatedY;
+            member.rotation = normaliseDeg((member.rotation || 0) + deltaDeg);
+        });
+    }
+
+    function translateSection(sectionId, deltaX, deltaY) {
+        const members = getSectionMembers(sectionId);
+        members.forEach(member => {
+            member.x += deltaX;
+            member.y += deltaY;
+        });
+    }
+
+    function mergeSections(sectionA, sectionB) {
+        if (!sectionA || !sectionB || sectionA === sectionB) {
+            return;
+        }
+        const target = sectionA < sectionB ? sectionA : sectionB;
+        placements.forEach(item => {
+            if (item.sectionId === sectionA || item.sectionId === sectionB) {
+                item.sectionId = target;
+            }
+        });
+        return target;
+    }
+
+    function snapSelectedToNearest() {
+        const placement = placements.find(p => p.id === selectedId);
+        if (!placement) {
+            return;
+        }
+        const localEndpoints = getPlacementLocalEndpoints(placement);
+        if (!localEndpoints.length) {
+            return;
+        }
+        const currentRotation = normaliseDeg(placement.rotation || 0);
+        let best = null;
+        placements.forEach(target => {
+            if (target.id === placement.id) {
+                return;
+            }
+            const targetEndpoints = getPlacementWorldEndpoints(target);
+            targetEndpoints.forEach(targetEp => {
+                localEndpoints.forEach(localEp => {
+                    const desiredRotation = normaliseDeg(radToDeg(targetEp.tangentAngle + Math.PI - localEp.localTangentAngle));
+                    const deltaRot = desiredRotation - currentRotation;
+                    let adjustedDelta = deltaRot;
+                    if (adjustedDelta > 180) {
+                        adjustedDelta -= 360;
+                    }
+                    if (adjustedDelta < -180) {
+                        adjustedDelta += 360;
+                    }
+                    const rotatedLocal = rotatePoint(localEp.localPoint, degToRad(desiredRotation));
+                    const desiredX = targetEp.point.x - rotatedLocal.x;
+                    const desiredY = targetEp.point.y - rotatedLocal.y;
+                    const deltaX = desiredX - placement.x;
+                    const deltaY = desiredY - placement.y;
+                    const movementScore = (deltaX * deltaX + deltaY * deltaY) + Math.pow(adjustedDelta * 5, 2);
+                    if (!best || movementScore < best.score) {
+                        best = {
+                            score: movementScore,
+                            desiredRotation,
+                            desiredX,
+                            desiredY,
+                            targetSection: target.sectionId,
+                        };
+                    }
+                });
+            });
+        });
+        if (!best) {
+            return;
+        }
+        const targetRotation = best.desiredRotation;
+        const rotationDelta = targetRotation - currentRotation;
+        let adjustedDelta = rotationDelta;
+        if (adjustedDelta > 180) {
+            adjustedDelta -= 360;
+        }
+        if (adjustedDelta < -180) {
+            adjustedDelta += 360;
+        }
+        rotateSection(placement.sectionId, placement, adjustedDelta);
+        const selectedAfterRotate = placements.find(p => p.id === placement.id);
+        if (!selectedAfterRotate) {
+            return;
+        }
+        const translateX = best.desiredX - selectedAfterRotate.x;
+        const translateY = best.desiredY - selectedAfterRotate.y;
+        translateSection(placement.sectionId, translateX, translateY);
+        const finalSelected = placements.find(p => p.id === placement.id);
+        if (finalSelected) {
+            finalSelected.rotation = normaliseDeg(best.desiredRotation);
+        }
+        mergeSections(placement.sectionId, best.targetSection);
+        draw();
+        emitState();
+    }
+
+    function requestFrameHeight() {
+        window.parent.postMessage({
+            isStreamlitMessage: true,
+            type: "streamlit:setFrameHeight",
+            height: document.body.scrollHeight,
+        }, "*");
+    }
+
+    function addPiece(code) {
+        const piece = libraryByCode[code];
+        if (!piece) { return; }
+        const newPlacement = {
+            id: 'placement-' + nextId++,
+            code,
+            x: (minX + maxX) / 2,
+            y: (minY + maxY) / 2,
+            rotation: 0,
+            flipped: false,
+            sectionId: null,
+        };
+        newPlacement.sectionId = newPlacement.id;
+        placements.push(newPlacement);
+        selectedId = newPlacement.id;
+        updateSelectionLabel();
+        draw();
+        emitState();
+    }
+
+    function updateSelectionLabel() {
+        const label = document.getElementById('selectionLabel');
+        const placement = placements.find(p => p.id === selectedId);
+        if (!placement) {
+            label.textContent = 'No piece selected';
+        } else {
+            const piece = libraryByCode[placement.code];
+            const base = placement.code + ' · ' + (piece ? piece.name : '');
+            label.textContent = applySection ? base + ' (section ' + placement.sectionId + ')' : base;
+        }
+    }
+
+    document.querySelectorAll('.add-piece').forEach(button => {
+        button.addEventListener('click', event => {
+            const code = event.currentTarget.getAttribute('data-code');
+            addPiece(code);
+        });
+    });
+
+    const sectionToggle = document.getElementById('sectionMode');
+    if (sectionToggle) {
+        sectionToggle.addEventListener('change', event => {
+            applySection = event.target.checked;
+            updateSelectionLabel();
+        });
+    }
+
+    let dragging = false;
+    let dragOffset = { x: 0, y: 0 };
+
+    canvas.addEventListener('pointerdown', event => {
+        const rect = canvas.getBoundingClientRect();
+        const { x, y } = canvasToMm(event.clientX - rect.left, event.clientY - rect.top);
+        let found = null;
+        for (let i = placements.length - 1; i >= 0; i -= 1) {
+            if (hitTest(placements[i], x, y)) {
+                found = placements[i];
+                break;
+            }
+        }
+        if (found) {
+            selectedId = found.id;
+            if (applySection) {
+                draggingSection = true;
+                pointerStart = { x, y };
+                const members = getSectionMembers(found.sectionId);
+                sectionOriginals = members.map(member => ({
+                    id: member.id,
+                    x: member.x,
+                    y: member.y,
+                }));
+                sectionOriginalMap = {};
+                sectionOriginals.forEach(item => {
+                    sectionOriginalMap[item.id] = { x: item.x, y: item.y };
+                });
+            } else {
+                draggingSection = false;
+                dragOffset = { x: x - found.x, y: y - found.y };
+            }
+            dragging = true;
+            canvas.setPointerCapture(event.pointerId);
+            updateSelectionLabel();
+            draw();
+        } else {
+            selectedId = null;
+            draggingSection = false;
+            updateSelectionLabel();
+            draw();
+        }
+    });
+
+    canvas.addEventListener('pointermove', event => {
+        if (!dragging || !selectedId) { return; }
+        const placement = placements.find(p => p.id === selectedId);
+        if (!placement) { return; }
+        const rect = canvas.getBoundingClientRect();
+        const { x, y } = canvasToMm(event.clientX - rect.left, event.clientY - rect.top);
+        if (draggingSection) {
+            if (!pointerStart) {
+                pointerStart = { x, y };
+            }
+            const deltaX = x - pointerStart.x;
+            const deltaY = y - pointerStart.y;
+            const members = getSectionMembers(placement.sectionId);
+            members.forEach(member => {
+                const original = sectionOriginalMap[member.id];
+                if (original) {
+                    member.x = original.x + deltaX;
+                    member.y = original.y + deltaY;
+                }
+            });
+        } else {
+            placement.x = x - dragOffset.x;
+            placement.y = y - dragOffset.y;
+        }
+        draw();
+    });
+
+    canvas.addEventListener('pointerup', event => {
+        dragging = false;
+        draggingSection = false;
+        sectionOriginals = [];
+        sectionOriginalMap = {};
+        pointerStart = null;
+        if (canvas.hasPointerCapture(event.pointerId)) {
+            canvas.releasePointerCapture(event.pointerId);
+        }
+        emitState();
+    });
+
+    function hitTest(placement, x, y) {
+        const piece = libraryByCode[placement.code];
+        if (!piece) { return false; }
+        const rotation = (placement.rotation || 0) * Math.PI / 180;
+        const dx = x - placement.x;
+        const dy = y - placement.y;
+        const cos = Math.cos(rotation);
+        const sin = Math.sin(rotation);
+        const localX = cos * dx + sin * dy;
+        const localY = -sin * dx + cos * dy;
+        if (piece.kind === 'curve' && piece.radius) {
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            return Math.abs(dist - piece.radius) < 60;
+        }
+        const length = piece.displayLength || piece.length || 0;
+        return Math.abs(localX) <= length / 2 && Math.abs(localY) <= 50;
+    }
+
+    function adjustSelected(deltaRotation = 0, deltaX = 0, deltaY = 0) {
+        const placement = placements.find(p => p.id === selectedId);
+        if (!placement) { return; }
+        if (applySection) {
+            if (deltaRotation) {
+                rotateSection(placement.sectionId, placement, deltaRotation);
+            }
+            if (deltaX || deltaY) {
+                translateSection(placement.sectionId, deltaX, deltaY);
+            }
+        } else {
+            placement.rotation = normaliseDeg(((placement.rotation || 0) + deltaRotation));
+            placement.x += deltaX;
+            placement.y += deltaY;
+        }
+        draw();
+        emitState();
+    }
+
+    document.getElementById('rotateLeft').addEventListener('click', () => adjustSelected(-15, 0, 0));
+    document.getElementById('rotateRight').addEventListener('click', () => adjustSelected(15, 0, 0));
+    document.getElementById('nudgeUp').addEventListener('click', () => adjustSelected(0, 0, 10));
+    document.getElementById('nudgeDown').addEventListener('click', () => adjustSelected(0, 0, -10));
+    document.getElementById('nudgeLeft').addEventListener('click', () => adjustSelected(0, -10, 0));
+    document.getElementById('nudgeRight').addEventListener('click', () => adjustSelected(0, 10, 0));
+    document.getElementById('flipPiece').addEventListener('click', () => {
+        const placement = placements.find(p => p.id === selectedId);
+        if (!placement) { return; }
+        placement.flipped = !placement.flipped;
+        draw();
+        emitState();
+    });
+    document.getElementById('snapGrid').addEventListener('click', () => {
+        const placement = placements.find(p => p.id === selectedId);
+        if (!placement) { return; }
+        const targets = applySection ? getSectionMembers(placement.sectionId) : [placement];
+        targets.forEach(item => {
+            item.x = Math.round(item.x / 10) * 10;
+            item.y = Math.round(item.y / 10) * 10;
+            item.rotation = Math.round((item.rotation || 0) / 15) * 15;
+            item.rotation = normaliseDeg(item.rotation);
+        });
+        draw();
+        emitState();
+    });
+    document.getElementById('snapConnect').addEventListener('click', () => {
+        snapSelectedToNearest();
+    });
+    document.getElementById('deletePiece').addEventListener('click', () => {
+        const index = placements.findIndex(p => p.id === selectedId);
+        if (index === -1) { return; }
+        placements.splice(index, 1);
+        selectedId = placements.length ? placements[placements.length - 1].id : null;
+        updateSelectionLabel();
+        draw();
+        emitState();
+    });
+
+    window.addEventListener('resize', resizeCanvas);
+    resizeCanvas();
+    updateSelectionLabel();
+    requestFrameHeight();
+    </script>
+    """
+    )
+
+    html = html_template.substitute(
+        library_cards="".join(library_cards),
+        board_json=json.dumps(board_payload),
+        track_json=json.dumps(track_payload),
+        placements_json=json.dumps(placements),
+    )
+
+    component_value = components.html(html, height=720, scrolling=True)
+    if component_value is None:
+        return placements
+    parsed: Dict[str, object]
+    if isinstance(component_value, str):
+        try:
+            parsed = json.loads(component_value)
+        except json.JSONDecodeError:
+            return placements
+    elif isinstance(component_value, dict):
+        parsed = component_value
+    else:
+        return placements
+    payload = parsed.get("placements") if isinstance(parsed, dict) else None
+    if isinstance(payload, list):
+        return [p for p in payload if isinstance(p, dict)]
+    return placements
 
 
 board = _board_controls()
-objectives, allowed_radii = _objective_controls()
-st.sidebar.header("Results")
-max_layouts = st.sidebar.slider("Number of layout options", min_value=1, max_value=6, value=3)
+st.sidebar.success(describe_board(board))
 
-st.info(describe_board(board))
+if "placements" not in st.session_state:
+    st.session_state["placements"] = []
 
-if allowed_radii:
-    allowed_radii_set = set(allowed_radii)
+placements: List[Dict[str, object]] = st.session_state["placements"]
+placements = _designer(board, placements)
+st.session_state["placements"] = placements
+
+
+library = hornby_track_library()
+inventory = inventory_from_placements(placements)
+total_length_mm = total_run_length_mm(placements)
+
+st.subheader("Inventory summary")
+cols = st.columns(3)
+cols[0].metric("Pieces placed", sum(inventory.values()))
+cols[1].metric("Unique catalogue items", len(inventory))
+cols[2].metric("Run length", f"{total_length_mm/1000:.2f} m")
+
+if inventory:
+    rows = []
+    for code, count in sorted(inventory.items()):
+        piece = library.get(code)
+        rows.append(
+            {
+                "Catalogue": code,
+                "Piece": piece.name if piece else "Unknown",
+                "Quantity": count,
+                "Length (mm)": f"{piece.arc_length():.0f}" if piece and piece.kind == "curve" else (f"{piece.length:.0f}" if piece else "-"),
+            }
+        )
+    st.dataframe(rows, hide_index=True, use_container_width=True)
 else:
-    allowed_radii_set = set()
-
-generator = get_generator()
-layouts = generator.generate(board, set(objectives), allowed_radii_set, max_layouts=max_layouts)
-
-if not layouts:
-    st.warning("No layouts match the chosen board size and goals. Try expanding the allowed radii or relaxing priorities.")
-else:
-    for plan in layouts:
-        st.divider()
-        _render_plan(plan, board)
+    st.info("Add pieces from the library to begin building your layout.")

--- a/planner.py
+++ b/planner.py
@@ -1,8 +1,8 @@
-"""Layout planning utilities for the Streamlit Hornby OO gauge planner app."""
+"""Utility primitives for the interactive Hornby OO layout planner."""
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Callable, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import math
 
@@ -26,568 +26,125 @@ class TrackPiece:
 
 
 TRACK_LIBRARY: Dict[str, TrackPiece] = {
+    # Core straights
     "R600": TrackPiece("R600", "Standard Straight", "straight", 168.0),
     "R601": TrackPiece("R601", "Double Straight", "straight", 335.5),
+    "R602": TrackPiece("R602", "Short Straight", "straight", 111.0),
     "R603": TrackPiece("R603", "Half Straight", "straight", 67.0),
     "R604": TrackPiece("R604", "Quarter Straight", "straight", 41.0),
-    "R606": TrackPiece("R606", "1st Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=371.0),
-    "R607": TrackPiece("R607", "2nd Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=438.0),
-    "R608": TrackPiece("R608", "3rd Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=505.0),
-    "R609": TrackPiece("R609", "4th Radius Curve (45°)", "curve", length=0.0, angle=45.0, radius=572.0),
-    "R610": TrackPiece("R610", "1st Radius Curve (22.5°)", "curve", length=0.0, angle=22.5, radius=371.0),
-    "R614": TrackPiece("R614", "90° Crossing", "special", 168.0),
+    "R618": TrackPiece("R618", "Buffer Stop Track", "special", 76.0),
+    "R627": TrackPiece("R627", "Level Crossing Straight", "special", 168.0),
+    # Flexible and specialist straights
+    "R6102": TrackPiece("R6102", "Flexi Track (914mm)", "flex", 914.0),
+    "R6143": TrackPiece("R6143", "Platform Straight", "special", 168.0),
+    # Curves by radius and angle
+    "R605": TrackPiece("R605", "1st Radius Curve (90°)", "curve", 0.0, angle=90.0, radius=371.0),
+    "R606": TrackPiece("R606", "1st Radius Curve (45°)", "curve", 0.0, angle=45.0, radius=371.0),
+    "R607": TrackPiece("R607", "2nd Radius Curve (45°)", "curve", 0.0, angle=45.0, radius=438.0),
+    "R608": TrackPiece("R608", "3rd Radius Curve (45°)", "curve", 0.0, angle=45.0, radius=505.0),
+    "R609": TrackPiece("R609", "4th Radius Curve (45°)", "curve", 0.0, angle=45.0, radius=572.0),
+    "R610": TrackPiece("R610", "1st Radius Curve (22.5°)", "curve", 0.0, angle=22.5, radius=371.0),
+    "R611": TrackPiece("R611", "2nd Radius Curve (22.5°)", "curve", 0.0, angle=22.5, radius=438.0),
+    "R612": TrackPiece("R612", "3rd Radius Curve (22.5°)", "curve", 0.0, angle=22.5, radius=505.0),
+    "R613": TrackPiece("R613", "4th Radius Curve (22.5°)", "curve", 0.0, angle=22.5, radius=572.0),
+    # Points, crossings and specialist pieces
     "R8072": TrackPiece("R8072", "Left-hand Point", "point", 168.0),
     "R8073": TrackPiece("R8073", "Right-hand Point", "point", 168.0),
+    "R8074": TrackPiece("R8074", "Y Point", "point", 168.0),
+    "R8075": TrackPiece("R8075", "Curved Point LH", "point", 168.0, angle=22.5, radius=371.0),
+    "R8076": TrackPiece("R8076", "Curved Point RH", "point", 168.0, angle=22.5, radius=371.0),
+    "R8099": TrackPiece("R8099", "Double Slip", "special", 168.0),
+    "R614": TrackPiece("R614", "90° Crossing", "special", 168.0),
+    "R615": TrackPiece("R615", "30° Crossing", "special", 168.0),
+    "R628": TrackPiece("R628", "Diamond Crossing", "special", 168.0),
 }
 
 
 @dataclass
-class GeometryCommand:
-    """Instruction used to draw the preview of a layout."""
-
-    command: str
-    parameters: Tuple[float, ...]
-
-
-@dataclass
-class LayoutPlan:
-    """Full definition of a layout proposal."""
-
-    name: str
-    description: str
-    pieces: Dict[str, int]
-    footprint: Tuple[float, float]
-    features: Set[str]
-    radii_used: Set[float]
-    notes: List[str] = field(default_factory=list)
-    geometry_factory: Optional[Callable[["LayoutPlan"], List[GeometryCommand]]] = None
-
-    def total_length_mm(self) -> float:
-        total = 0.0
-        for code, count in self.pieces.items():
-            piece = TRACK_LIBRARY.get(code)
-            if not piece:
-                continue
-            if piece.kind == "curve":
-                total += piece.arc_length() * count
-            else:
-                total += piece.length * count
-        return total
-
-    def straight_length_mm(self) -> float:
-        total = 0.0
-        for code, count in self.pieces.items():
-            piece = TRACK_LIBRARY.get(code)
-            if not piece:
-                continue
-            if piece.kind in {"straight", "point", "special"}:
-                total += piece.length * count
-        return total
-
-    def curve_length_mm(self) -> float:
-        total = 0.0
-        for code, count in self.pieces.items():
-            piece = TRACK_LIBRARY.get(code)
-            if not piece:
-                continue
-            if piece.kind == "curve":
-                total += piece.arc_length() * count
-        return total
-
-    def piece_breakdown(self) -> List[Tuple[str, str, int]]:
-        breakdown: List[Tuple[str, str, int]] = []
-        for code, count in sorted(self.pieces.items()):
-            piece = TRACK_LIBRARY.get(code)
-            name = piece.name if piece else "Unknown"
-            breakdown.append((code, name, count))
-        return breakdown
-
-    def build_geometry(self) -> List[GeometryCommand]:
-        if self.geometry_factory is None:
-            return []
-        return self.geometry_factory(self)
-
-    def fits_within(self, width: float, height: float) -> bool:
-        footprint_width, footprint_height = self.footprint
-        return footprint_width <= width and footprint_height <= height
-
-
-@dataclass
 class BoardSpecification:
+    """Representation of the work surface for the layout designer."""
+
     shape: str
     width: float
     height: float
     polygon: Optional[List[Tuple[float, float]]] = None
 
     def bounding_box(self) -> Tuple[float, float]:
-        if self.shape == "custom" and self.polygon:
-            xs = [p[0] for p in self.polygon]
-            ys = [p[1] for p in self.polygon]
-            return max(xs) - min(xs), max(ys) - min(ys)
-        return self.width, self.height
-
-
-def _linspace(start: float, end: float, steps: int) -> List[float]:
-    if steps <= 1:
-        return [start]
-    delta = (end - start) / (steps - 1)
-    return [start + i * delta for i in range(steps)]
-
-
-def _oval_points(
-    radius: float,
-    straight_total: float,
-    offset: Tuple[float, float] = (0.0, 0.0),
-    samples: int = 120,
-) -> List[Tuple[float, float]]:
-    """Create a closed oval represented as (x, y) coordinate pairs."""
-
-    quarter = max(2, samples // 4)
-    half_straight = straight_total / 2.0
-    ox, oy = offset
-
-    points: List[Tuple[float, float]] = []
-
-    # Top straight (right to left for continuity)
-    for x in _linspace(half_straight, -half_straight, quarter):
-        points.append((ox + x, oy + radius))
-
-    # Left arc (90° to 270°)
-    for theta in _linspace(math.pi / 2, 3 * math.pi / 2, quarter):
-        x = -half_straight + radius * math.cos(theta)
-        y = radius * math.sin(theta)
-        points.append((ox + x, oy + y))
-
-    # Bottom straight (left to right)
-    for x in _linspace(-half_straight, half_straight, quarter):
-        points.append((ox + x, oy - radius))
-
-    # Right arc (-90° to 90°)
-    for theta in _linspace(-math.pi / 2, math.pi / 2, quarter):
-        x = half_straight + radius * math.cos(theta)
-        y = radius * math.sin(theta)
-        points.append((ox + x, oy + y))
-
-    if points:
-        points.append(points[0])
-    return points
-
-
-def render_geometry_svg(
-    commands: Sequence[GeometryCommand],
-    board_width: float,
-    board_height: float,
-) -> str:
-    """Render layout geometry to an SVG snippet suitable for embedding in Streamlit."""
-
-    if not commands:
-        return (
-            "<div style=\"border:1px solid #e6e6e6;padding:0.5rem;background-color:#fafafa;\">"
-            "<p><em>No track preview available for this layout.</em></p>"
-            "</div>"
-        )
-
-    track_shapes: List[Tuple[str, List[Tuple[float, float]]]] = []
-    line_shapes: List[Tuple[str, Tuple[float, float, float, float]]] = []
-    markers: List[Tuple[float, float]] = []
-
-    min_x = float("inf")
-    max_x = float("-inf")
-    min_y = float("inf")
-    max_y = float("-inf")
-
-    def include_point(x: float, y: float) -> None:
-        nonlocal min_x, max_x, min_y, max_y
-        min_x = min(min_x, x)
-        max_x = max(max_x, x)
-        min_y = min(min_y, y)
-        max_y = max(max_y, y)
-
-    if board_width > 0 and board_height > 0:
-        half_w = board_width / 2.0
-        half_h = board_height / 2.0
-        include_point(-half_w, -half_h)
-        include_point(half_w, half_h)
-
-    for command in commands:
-        if command.command == "oval":
-            radius, straight_total, ox, oy = command.parameters
-            pts = _oval_points(radius, straight_total, (ox, oy))
-            for x, y in pts:
-                include_point(x, y)
-            track_shapes.append(("oval", pts))
-        elif command.command in {"line", "siding"}:
-            x1, y1, x2, y2 = command.parameters
-            include_point(x1, y1)
-            include_point(x2, y2)
-            line_shapes.append((command.command, (x1, y1, x2, y2)))
-        elif command.command == "marker":
-            x, y = command.parameters
-            include_point(x, y)
-            markers.append((x, y))
-
-    if min_x == float("inf"):
-        min_x, max_x = -500.0, 500.0
-        min_y, max_y = -500.0, 500.0
-
-    margin = 150.0
-    min_x -= margin
-    max_x += margin
-    min_y -= margin
-    max_y += margin
-
-    span_x = max(max_x - min_x, 1.0)
-    span_y = max(max_y - min_y, 1.0)
-
-    def to_svg_point(x: float, y: float) -> Tuple[float, float]:
-        return x - min_x, max_y - y
-
-    parts: List[str] = []
-    parts.append(
-        "<div style=\"border:1px solid #e6e6e6;padding:0.5rem;background-color:#fafafa;\">"
-    )
-    parts.append(
-        f'<svg viewBox="0 0 {span_x:.1f} {span_y:.1f}" '
-        "preserveAspectRatio=\"xMidYMid meet\" style=\"width:100%;height:auto;\">"
-    )
-
-    if board_width > 0 and board_height > 0:
-        half_w = board_width / 2.0
-        half_h = board_height / 2.0
-        top_left = to_svg_point(-half_w, half_h)
-        parts.append(
-            f'<rect x="{top_left[0]:.1f}" y="{top_left[1]:.1f}" '
-            f'width="{board_width:.1f}" height="{board_height:.1f}" '
-            'fill="none" stroke="#555555" stroke-dasharray="6 6" stroke-width="2" />'
-        )
-
-    for _, pts in track_shapes:
-        svg_points = " ".join(
-            f"{to_svg_point(x, y)[0]:.1f},{to_svg_point(x, y)[1]:.1f}" for x, y in pts
-        )
-        parts.append(
-            f'<polyline points="{svg_points}" fill="none" stroke="#1f77b4" stroke-width="4" />'
-        )
-
-    for kind, (x1, y1, x2, y2) in line_shapes:
-        sx1, sy1 = to_svg_point(x1, y1)
-        sx2, sy2 = to_svg_point(x2, y2)
-        dash = ' stroke-dasharray="10 6"' if kind == "siding" else ""
-        colour = "#ff7f0e" if kind == "siding" else "#1f77b4"
-        parts.append(
-            f'<line x1="{sx1:.1f}" y1="{sy1:.1f}" x2="{sx2:.1f}" y2="{sy2:.1f}" '
-            f'stroke="{colour}" stroke-width="4"{dash} />'
-        )
-
-    for x, y in markers:
-        sx, sy = to_svg_point(x, y)
-        parts.append(
-            f'<circle cx="{sx:.1f}" cy="{sy:.1f}" r="6" fill="#2ca02c" />'
-        )
-
-    parts.append("</svg>")
-    parts.append("</div>")
-    return "".join(parts)
-
-
-class LayoutGenerator:
-    """Selects layout templates that meet the user's brief."""
-
-    def __init__(self, templates: Iterable[LayoutPlan]):
-        self.templates = list(templates)
-
-    def generate(
-        self,
-        board: BoardSpecification,
-        objectives: Set[str],
-        allowed_radii: Set[float],
-        max_layouts: int = 5,
-    ) -> List[LayoutPlan]:
-        width, height = board.bounding_box()
-        required_features = set()
-        if "Include loops" in objectives:
-            required_features.add("loop")
-        if "Include spurs/sidings" in objectives:
-            required_features.add("spur")
-        if "Include fiddle yard" in objectives:
-            required_features.add("fiddle_yard")
-
-        candidates: List[Tuple[float, LayoutPlan]] = []
-        for template in self.templates:
-            if not template.fits_within(width, height):
-                continue
-            if required_features and not required_features.issubset(template.features):
-                continue
-            if allowed_radii and not template.radii_used.issubset(allowed_radii):
-                continue
-
-            score = self._score(template, objectives)
-            candidates.append((score, template))
-
-        reverse = True
-        if "Minimise total track" in objectives and "Maximise track coverage" not in objectives:
-            reverse = False
-
-        candidates.sort(key=lambda item: item[0], reverse=reverse)
-        return [tpl for _, tpl in candidates[:max_layouts]]
-
-    def _score(self, template: LayoutPlan, objectives: Set[str]) -> float:
-        total = template.total_length_mm()
-        straights = template.straight_length_mm()
-        score = 0.0
-        if not objectives:
-            score = total
-        if "Maximise track coverage" in objectives:
-            score += total
-        if "Maximise straight running" in objectives:
-            score += straights * 1.25
-        if "Minimise total track" in objectives:
-            score -= total
-        if "Encourage complex operations" in objectives and "fiddle_yard" in template.features:
-            score += 500.0
-        if "Encourage complex operations" in objectives and "spur" in template.features:
-            score += 250.0
-        if "Prefer multiple loops" in objectives and "multi_loop" in template.features:
-            score += 500.0
-        return score
-
-
-CLEARANCE = 120.0  # mm of margin around templates to give realistic space
-
-
-def _oval_geometry_factory(radius: float, straight_count: int, straight_code: str) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    piece = TRACK_LIBRARY[straight_code]
-    straight_total = piece.length * (straight_count / 2)
-
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        return [GeometryCommand("oval", (radius, straight_total, 0.0, 0.0))]
-
-    return factory
-
-
-def _oval_with_siding_geometry_factory(radius: float, straight_code: str, siding_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    piece = TRACK_LIBRARY[straight_code]
-    straight_total = piece.length * 2
-
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        commands = [GeometryCommand("oval", (radius, straight_total, 0.0, 0.0))]
-        commands.append(
-            GeometryCommand(
-                "siding",
-                (-straight_total / 2, radius + 60.0, -straight_total / 2 - siding_length, radius + 60.0),
-            )
-        )
-        commands.append(
-            GeometryCommand(
-                "siding",
-                (-straight_total / 2 + 30.0, radius + 60.0, -straight_total / 2 + 30.0, radius + 120.0),
-            )
-        )
-        return commands
-
-    return factory
-
-
-def _double_oval_geometry_factory(inner_radius: float, outer_radius: float, straight_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    half = straight_length
-
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        commands = [
-            GeometryCommand("oval", (outer_radius, half * 2, 0.0, 0.0)),
-            GeometryCommand("oval", (inner_radius, (half - 60.0) * 2, 0.0, 0.0)),
-            GeometryCommand("line", (-half - inner_radius, 0.0, -half - inner_radius, -200.0)),
-            GeometryCommand("line", (-half - inner_radius, -200.0, -half + inner_radius, -200.0)),
-        ]
-        return commands
-
-    return factory
-
-
-def _figure_eight_geometry_factory(radius: float, straight_length: float) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    half = straight_length / 2
-
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        left_center = (-half, 0.0)
-        right_center = (half, 0.0)
-        commands = [GeometryCommand("line", (left_center[0], radius, right_center[0], -radius))]
-        commands.append(GeometryCommand("oval", (radius, straight_length, *left_center)))
-        commands.append(GeometryCommand("oval", (radius, straight_length, *right_center)))
-        return commands
-
-    return factory
-
-
-def _fiddle_yard_geometry_factory(main_length: float, sidings: int, spacing: float = 70.0) -> Callable[[LayoutPlan], List[GeometryCommand]]:
-    def factory(_: LayoutPlan) -> List[GeometryCommand]:
-        commands = [GeometryCommand("line", (-main_length / 2, 0.0, main_length / 2, 0.0))]
-        for i in range(1, sidings + 1):
-            offset = i * spacing
-            commands.append(GeometryCommand("siding", (-main_length / 2 + 200.0, offset, main_length / 2, offset)))
-        return commands
-
-    return factory
-
-
-def default_templates() -> List[LayoutPlan]:
-    templates: List[LayoutPlan] = []
-
-    # Compact oval (1st radius)
-    radius = TRACK_LIBRARY["R606"].radius or 0.0
-    straight_piece = TRACK_LIBRARY["R600"].length
-    straight_total = straight_piece * 2
-    footprint = (2 * radius + straight_total + CLEARANCE, 2 * radius + CLEARANCE)
-    templates.append(
-        LayoutPlan(
-            name="Compact Continuous Oval",
-            description="A simple 1st radius oval ideal for very small boards and continuous running.",
-            pieces={"R606": 8, "R600": 4},
-            footprint=footprint,
-            features={"loop", "compact"},
-            radii_used={radius},
-            notes=["Add power clips to any straight for track power."],
-            geometry_factory=_oval_geometry_factory(radius, 4, "R600"),
-        )
-    )
-
-    # Standard oval with passing loop
-    radius = TRACK_LIBRARY["R607"].radius or 0.0
-    straight_length = TRACK_LIBRARY["R600"].length
-    straight_total = straight_length * 2
-    footprint = (2 * radius + straight_total + CLEARANCE + 180.0, 2 * radius + CLEARANCE + 140.0)
-    templates.append(
-        LayoutPlan(
-            name="Passing Loop Oval",
-            description="2nd radius oval with a passing loop for two-train operation or station stops.",
-            pieces={
-                "R607": 8,
-                "R600": 6,
-                "R603": 2,
-                "R8072": 1,
-                "R8073": 1,
-            },
-            footprint=footprint,
-            features={"loop", "spur"},
-            radii_used={radius},
-            notes=["Points form a loop on the top straight allowing trains to pass."],
-            geometry_factory=_oval_with_siding_geometry_factory(radius, "R600", 400.0),
-        )
-    )
-
-    # Double track oval
-    inner_radius = TRACK_LIBRARY["R607"].radius or 0.0
-    outer_radius = TRACK_LIBRARY["R608"].radius or 0.0
-    straight_length = TRACK_LIBRARY["R600"].length * 2
-    footprint = (2 * outer_radius + straight_length + CLEARANCE + 160.0, 2 * outer_radius + CLEARANCE + 120.0)
-    templates.append(
-        LayoutPlan(
-            name="Twin Track Mainline",
-            description="Paired 2nd and 3rd radius loops for continuous two-train running with a crossover.",
-            pieces={
-                "R608": 8,
-                "R607": 8,
-                "R600": 8,
-                "R8072": 2,
-                "R8073": 2,
-            },
-            footprint=footprint,
-            features={"loop", "multi_loop", "max_track"},
-            radii_used={inner_radius, outer_radius},
-            notes=["Use opposing points as a scissors crossover between the loops."],
-            geometry_factory=_double_oval_geometry_factory(inner_radius, outer_radius, straight_length / 2),
-        )
-    )
-
-    # Large oval with fiddle yard
-    radius = TRACK_LIBRARY["R609"].radius or 0.0
-    straight_length = TRACK_LIBRARY["R601"].length * 2
-    footprint = (2 * radius + straight_length + CLEARANCE + 420.0, 2 * radius + CLEARANCE + 200.0)
-    templates.append(
-        LayoutPlan(
-            name="Mainline with Fiddle Yard",
-            description="4th radius oval with extended straights feeding a three-road fiddle yard.",
-            pieces={
-                "R609": 8,
-                "R601": 4,
-                "R8072": 3,
-                "R8073": 3,
-                "R600": 6,
-            },
-            footprint=footprint,
-            features={"loop", "fiddle_yard", "spur", "max_track"},
-            radii_used={radius},
-            notes=["Three sidings can store full-length trains ready to enter the mainline."],
-            geometry_factory=_fiddle_yard_geometry_factory(straight_length + 2 * radius, sidings=3),
-        )
-    )
-
-    # End-to-end with fiddle yard
-    main_length = 2400.0
-    footprint = (main_length + CLEARANCE, 600.0 + CLEARANCE)
-    templates.append(
-        LayoutPlan(
-            name="End-to-End Terminus",
-            description="End-to-end layout with a three road fiddle yard and long platform straight.",
-            pieces={
-                "R601": 8,
-                "R600": 6,
-                "R603": 4,
-                "R8072": 3,
-                "R8073": 3,
-            },
-            footprint=footprint,
-            features={"fiddle_yard", "spur", "terminus"},
-            radii_used=set(),
-            notes=["Ideal for shunting and timetable operations without requiring continuous running."],
-            geometry_factory=_fiddle_yard_geometry_factory(main_length, sidings=3),
-        )
-    )
-
-    # Compact shunting puzzle
-    footprint = (1600.0 + CLEARANCE, 600.0 + CLEARANCE)
-    templates.append(
-        LayoutPlan(
-            name="Shunting Puzzle Yard",
-            description="A Inglenook-inspired yard using set-track pieces for switching challenges.",
-            pieces={
-                "R600": 10,
-                "R603": 6,
-                "R604": 4,
-                "R8072": 2,
-                "R8073": 1,
-            },
-            footprint=footprint,
-            features={"spur", "operations"},
-            radii_used=set(),
-            notes=["Lengths suit three wagon trains in the longest siding and two wagons elsewhere."],
-            geometry_factory=_fiddle_yard_geometry_factory(1200.0, sidings=2),
-        )
-    )
-
-    # Figure eight continuous run
-    radius = TRACK_LIBRARY["R607"].radius or 0.0
-    straight_length = TRACK_LIBRARY["R600"].length * 2
-    footprint = (straight_length * 2 + 2 * radius + CLEARANCE, 2 * radius + straight_length + CLEARANCE)
-    templates.append(
-        LayoutPlan(
-            name="Figure Eight with Crossing",
-            description="Continuous run with grade-level crossover for visual interest and reversing loops.",
-            pieces={
-                "R607": 16,
-                "R600": 4,
-                "R614": 1,
-            },
-            footprint=footprint,
-            features={"loop", "crossover", "max_track"},
-            radii_used={radius},
-            notes=["Consider using power districts to avoid shorts through the crossing."],
-            geometry_factory=_figure_eight_geometry_factory(radius, straight_length),
-        )
-    )
-
-    return templates
+        """Return width/height of the board envelope."""
+        points = self.polygon_points()
+        if not points:
+            return self.width, self.height
+        xs = [p[0] for p in points]
+        ys = [p[1] for p in points]
+        return max(xs) - min(xs), max(ys) - min(ys)
+
+    def polygon_points(self) -> List[Tuple[float, float]]:
+        """Return the polygon describing the working area."""
+        if self.polygon:
+            return list(self.polygon)
+        if self.shape == "rectangle":
+            return [
+                (0.0, 0.0),
+                (self.width, 0.0),
+                (self.width, self.height),
+                (0.0, self.height),
+            ]
+        if self.shape == "l-shape":
+            return [
+                (0.0, 0.0),
+                (self.width, 0.0),
+                (self.width, self.height / 2.0),
+                (self.height / 2.0, self.height / 2.0),
+                (self.height / 2.0, self.height),
+                (0.0, self.height),
+            ]
+        return []
+
+
+def hornby_track_library() -> Dict[str, TrackPiece]:
+    """Return the Hornby set-track items available to the designer."""
+
+    return TRACK_LIBRARY
+
+
+def piece_display_length(piece: TrackPiece) -> float:
+    """Return the running length of a track piece in millimetres."""
+
+    if piece.kind == "curve":
+        return piece.arc_length()
+    return piece.length
+
+
+def inventory_from_placements(placements: Sequence[Dict[str, object]]) -> Dict[str, int]:
+    """Calculate how many of each catalogue code have been placed."""
+
+    counts: Dict[str, int] = {}
+    for placement in placements:
+        code = placement.get("code")
+        if not isinstance(code, str):
+            continue
+        counts[code] = counts.get(code, 0) + 1
+    return counts
+
+
+def total_run_length_mm(placements: Sequence[Dict[str, object]]) -> float:
+    """Return the cumulative running length of the placed track pieces."""
+
+    total = 0.0
+    for placement in placements:
+        code = placement.get("code")
+        if not isinstance(code, str):
+            continue
+        piece = TRACK_LIBRARY.get(code)
+        if not piece:
+            continue
+        total += piece_display_length(piece)
+    return total
 
 
 def describe_board(board: BoardSpecification) -> str:
+    """Provide a human readable description of the board."""
+
     width, height = board.bounding_box()
     dims = f"{width/1000:.2f} m x {height/1000:.2f} m"
     if board.shape == "rectangle":


### PR DESCRIPTION
## Summary
- replace the automatic layout generator with board outline controls and manual polygon entry so the canvas matches the selected shape
- embed a Streamlit HTML/JS designer that renders the board, exposes the Hornby track library, and supports dragging, rotating, flipping, nudging, and snapping pieces
- expand the Hornby set-track catalogue and add helpers to total inventory counts and running length for live layout summaries
- add curve-aware snapping that aligns connection tangents, merges sections, and lets section-wide transforms keep groups oriented together

## Testing
- python -m compileall app.py planner.py

------
https://chatgpt.com/codex/tasks/task_e_68df71b00ac48324a50671eab42927f8