### PR TITLE
Improve board interaction controls

### DIFF
--- a/_layout_designer_component/index.html
+++ b/_layout_designer_component/index.html
@@ -1,21 +1,45 @@
 
     <style>
+    :root {
+        color-scheme: light;
+    }
+    html, body {
+        height: 100%;
+    }
+    body {
+        margin: 0;
+        font-family: 'Source Sans Pro', sans-serif;
+        background: linear-gradient(180deg, #eef1f5 0%, #e2e7f0 100%);
+        display: flex;
+        justify-content: center;
+        padding: 1.5rem;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
     .designer-wrapper {
         display: grid;
         grid-template-columns: minmax(0, 2.2fr) minmax(280px, 1fr);
         gap: 1.25rem;
-        align-items: flex-start;
-        font-family: 'Source Sans Pro', sans-serif;
+        align-items: stretch;
+        width: 100%;
+        max-width: 1480px;
+        height: 100%;
+        overflow: hidden;
     }
     .board-column {
         display: flex;
         flex-direction: column;
         gap: 1rem;
+        height: 100%;
+        overflow: hidden;
+        min-height: 0;
     }
     .board-canvas {
         display: flex;
         flex-direction: column;
         gap: 0.75rem;
+        flex: 1;
+        min-height: 0;
     }
     .board-surface {
         position: relative;
@@ -25,6 +49,9 @@
         overflow: hidden;
         min-height: 580px;
         height: min(900px, 72vh);
+        flex: 1;
+        min-height: 0;
+        box-shadow: 0 10px 28px rgba(31, 55, 90, 0.12);
     }
     #boardCanvas {
         width: 100%;
@@ -32,13 +59,15 @@
         touch-action: none;
         display: block;
     }
-    .view-controls {
+    .view-controls,
+    .board-controls {
         display: flex;
         flex-wrap: wrap;
         gap: 0.5rem;
         align-items: center;
     }
-    .view-controls label {
+    .view-controls label,
+    .board-controls span.label {
         font-weight: 600;
         font-size: 0.9rem;
     }
@@ -46,17 +75,25 @@
         flex: 1;
         min-width: 160px;
     }
-    .view-controls span {
+    .view-controls span,
+    .board-controls span.value {
         min-width: 3rem;
         text-align: right;
         font-variant-numeric: tabular-nums;
     }
-    .view-controls button {
+    .view-controls button,
+    .board-controls button {
         padding: 0.3rem 0.75rem;
         border-radius: 0.4rem;
         border: 1px solid #666666;
         background: #f8f8f8;
         cursor: pointer;
+    }
+    .board-controls {
+        justify-content: flex-start;
+    }
+    .board-controls span.value {
+        font-weight: 600;
     }
     .piece-controls {
         display: flex;
@@ -111,7 +148,7 @@
         gap: 0.75rem;
         position: sticky;
         top: 0;
-        max-height: calc(100vh - 140px);
+        max-height: 100%;
         overflow: auto;
     }
     .library-panel h3 {
@@ -212,9 +249,17 @@
         font-size: 0.8rem;
     }
     @media (max-width: 1100px) {
+        body {
+            overflow: auto;
+            padding: 1rem;
+        }
         .designer-wrapper {
             display: flex;
             flex-direction: column;
+            height: auto;
+        }
+        .board-column {
+            height: auto;
         }
         .library-panel {
             position: static;
@@ -233,6 +278,12 @@
                     <input type="range" id="zoomSlider" min="0.4" max="3" step="0.01" value="1" />
                     <span id="zoomValue">100%</span>
                     <button id="resetView" type="button">Reset view</button>
+                </div>
+                <div class="board-controls">
+                    <span class="label">Board orientation</span>
+                    <button id="boardRotateLeft" type="button">↺ 90°</button>
+                    <button id="boardRotateRight" type="button">↻ 90°</button>
+                    <span class="value" id="boardOrientationLabel">0°</span>
                 </div>
                 <div class="piece-controls">
                     <span id="selectionLabel">No piece selected</span>
@@ -268,13 +319,17 @@
     </div>
     <script src="https://unpkg.com/streamlit-component-lib/dist/index.js"></script>
     <script>
-    const boardData = {"polygon": [[0.0, 0.0], [1800.0, 0.0], [1800.0, 1200.0], [0.0, 1200.0]], "description": "Rectangular board 1.80 m x 1.20 m"};
-    const trackLibrary = [{"code": "R600", "name": "Standard Straight", "kind": "straight", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R601", "name": "Double Straight", "kind": "straight", "length": 335.5, "angle": null, "radius": null, "displayLength": 335.5}, {"code": "R602", "name": "Short Straight", "kind": "straight", "length": 111.0, "angle": null, "radius": null, "displayLength": 111.0}, {"code": "R603", "name": "Half Straight", "kind": "straight", "length": 67.0, "angle": null, "radius": null, "displayLength": 67.0}, {"code": "R604", "name": "Quarter Straight", "kind": "straight", "length": 41.0, "angle": null, "radius": null, "displayLength": 41.0}, {"code": "R618", "name": "Buffer Stop Track", "kind": "special", "length": 76.0, "angle": null, "radius": null, "displayLength": 76.0}, {"code": "R627", "name": "Level Crossing Straight", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R6102", "name": "Flexi Track (914mm)", "kind": "flex", "length": 914.0, "angle": null, "radius": null, "displayLength": 914.0}, {"code": "R6143", "name": "Platform Straight", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R605", "name": "1st Radius Curve (90\u00b0)", "kind": "curve", "length": 0.0, "angle": 90.0, "radius": 371.0, "displayLength": 582.7654372409066}, {"code": "R606", "name": "1st Radius Curve (45\u00b0)", "kind": "curve", "length": 0.0, "angle": 45.0, "radius": 371.0, "displayLength": 291.3827186204533}, {"code": "R607", "name": "2nd Radius Curve (45\u00b0)", "kind": "curve", "length": 0.0, "angle": 45.0, "radius": 438.0, "displayLength": 344.0043955680824}, {"code": "R608", "name": "3rd Radius Curve (45\u00b0)", "kind": "curve", "length": 0.0, "angle": 45.0, "radius": 505.0, "displayLength": 396.62607251571137}, {"code": "R609", "name": "4th Radius Curve (45\u00b0)", "kind": "curve", "length": 0.0, "angle": 45.0, "radius": 572.0, "displayLength": 449.2477494633404}, {"code": "R610", "name": "1st Radius Curve (22.5\u00b0)", "kind": "curve", "length": 0.0, "angle": 22.5, "radius": 371.0, "displayLength": 145.69135931022666}, {"code": "R611", "name": "2nd Radius Curve (22.5\u00b0)", "kind": "curve", "length": 0.0, "angle": 22.5, "radius": 438.0, "displayLength": 172.0021977840412}, {"code": "R612", "name": "3rd Radius Curve (22.5\u00b0)", "kind": "curve", "length": 0.0, "angle": 22.5, "radius": 505.0, "displayLength": 198.31303625785569}, {"code": "R613", "name": "4th Radius Curve (22.5\u00b0)", "kind": "curve", "length": 0.0, "angle": 22.5, "radius": 572.0, "displayLength": 224.6238747316702}, {"code": "R8072", "name": "Left-hand Point", "kind": "point", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R8073", "name": "Right-hand Point", "kind": "point", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R8074", "name": "Y Point", "kind": "point", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R8075", "name": "Curved Point LH", "kind": "point", "length": 168.0, "angle": 22.5, "radius": 371.0, "displayLength": 168.0}, {"code": "R8076", "name": "Curved Point RH", "kind": "point", "length": 168.0, "angle": 22.5, "radius": 371.0, "displayLength": 168.0}, {"code": "R8099", "name": "Double Slip", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R614", "name": "90\u00b0 Crossing", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R615", "name": "30\u00b0 Crossing", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R628", "name": "Diamond Crossing", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}];
+    let boardData = {"polygon": [[0.0, 0.0], [1800.0, 0.0], [1800.0, 1200.0], [0.0, 1200.0]], "description": "Rectangular board 1.80 m x 1.20 m", "orientation": 0.0};
+    let trackLibrary = [{"code": "R600", "name": "Standard Straight", "kind": "straight", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R601", "name": "Double Straight", "kind": "straight", "length": 335.5, "angle": null, "radius": null, "displayLength": 335.5}, {"code": "R602", "name": "Short Straight", "kind": "straight", "length": 111.0, "angle": null, "radius": null, "displayLength": 111.0}, {"code": "R603", "name": "Half Straight", "kind": "straight", "length": 67.0, "angle": null, "radius": null, "displayLength": 67.0}, {"code": "R604", "name": "Quarter Straight", "kind": "straight", "length": 41.0, "angle": null, "radius": null, "displayLength": 41.0}, {"code": "R618", "name": "Buffer Stop Track", "kind": "special", "length": 76.0, "angle": null, "radius": null, "displayLength": 76.0}, {"code": "R627", "name": "Level Crossing Straight", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R6102", "name": "Flexi Track (914mm)", "kind": "flex", "length": 914.0, "angle": null, "radius": null, "displayLength": 914.0}, {"code": "R6143", "name": "Platform Straight", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R605", "name": "1st Radius Curve (90\u00b0)", "kind": "curve", "length": 0.0, "angle": 90.0, "radius": 371.0, "displayLength": 582.7654372409066}, {"code": "R606", "name": "1st Radius Curve (45\u00b0)", "kind": "curve", "length": 0.0, "angle": 45.0, "radius": 371.0, "displayLength": 291.3827186204533}, {"code": "R607", "name": "2nd Radius Curve (45\u00b0)", "kind": "curve", "length": 0.0, "angle": 45.0, "radius": 438.0, "displayLength": 344.0043955680824}, {"code": "R608", "name": "3rd Radius Curve (45\u00b0)", "kind": "curve", "length": 0.0, "angle": 45.0, "radius": 505.0, "displayLength": 396.62607251571137}, {"code": "R609", "name": "4th Radius Curve (45\u00b0)", "kind": "curve", "length": 0.0, "angle": 45.0, "radius": 572.0, "displayLength": 449.2477494633404}, {"code": "R610", "name": "1st Radius Curve (22.5\u00b0)", "kind": "curve", "length": 0.0, "angle": 22.5, "radius": 371.0, "displayLength": 145.69135931022666}, {"code": "R611", "name": "2nd Radius Curve (22.5\u00b0)", "kind": "curve", "length": 0.0, "angle": 22.5, "radius": 438.0, "displayLength": 172.0021977840412}, {"code": "R612", "name": "3rd Radius Curve (22.5\u00b0)", "kind": "curve", "length": 0.0, "angle": 22.5, "radius": 505.0, "displayLength": 198.31303625785569}, {"code": "R613", "name": "4th Radius Curve (22.5\u00b0)", "kind": "curve", "length": 0.0, "angle": 22.5, "radius": 572.0, "displayLength": 224.6238747316702}, {"code": "R8072", "name": "Left-hand Point", "kind": "point", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R8073", "name": "Right-hand Point", "kind": "point", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R8074", "name": "Y Point", "kind": "point", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R8075", "name": "Curved Point LH", "kind": "point", "length": 168.0, "angle": 22.5, "radius": 371.0, "displayLength": 168.0}, {"code": "R8076", "name": "Curved Point RH", "kind": "point", "length": 168.0, "angle": 22.5, "radius": 371.0, "displayLength": 168.0}, {"code": "R8099", "name": "Double Slip", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R614", "name": "90\u00b0 Crossing", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R615", "name": "30\u00b0 Crossing", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}, {"code": "R628", "name": "Diamond Crossing", "kind": "special", "length": 168.0, "angle": null, "radius": null, "displayLength": 168.0}];
     const initialPlacements = [];
     const initialCircles = [];
     const initialZoom = 1.0;
-    const libraryByCode = Object.fromEntries(trackLibrary.map(item => [item.code, item]));
-    const placements = initialPlacements.map((item, idx) => ({
+    const colorPalette = ['#ff7f0e', '#9467bd', '#2ca02c', '#d62728', '#17becf', '#1f77b4'];
+    const queryParams = new URLSearchParams(window.location.search);
+    const componentId = queryParams.get('componentId');
+
+    let libraryByCode = Object.fromEntries(trackLibrary.map(item => [item.code, item]));
+    let placements = initialPlacements.map((item, idx) => ({
         id: item.id || ('placement-' + idx),
         code: item.code,
         x: typeof item.x === 'number' ? item.x : 0,
@@ -284,9 +339,56 @@
     }));
     let nextId = placements.length;
     let selectedId = placements.length ? placements[placements.length - 1].id : null;
-    const colorPalette = ['#ff7f0e', '#9467bd', '#2ca02c', '#d62728', '#17becf', '#1f77b4'];
-    const queryParams = new URLSearchParams(window.location.search);
-    const componentId = queryParams.get('componentId');
+
+    let boardOrientation = typeof boardData.orientation === 'number' ? boardData.orientation : 0;
+    const padding = 60;
+
+    function clonePoint(point) {
+        if (Array.isArray(point) && point.length >= 2) {
+            const x = Number(point[0]);
+            const y = Number(point[1]);
+            return [Number.isFinite(x) ? x : 0, Number.isFinite(y) ? y : 0];
+        }
+        if (point && typeof point === 'object') {
+            const x = Number(point.x);
+            const y = Number(point.y);
+            return [Number.isFinite(x) ? x : 0, Number.isFinite(y) ? y : 0];
+        }
+        return [0, 0];
+    }
+
+    function defaultPolygon() {
+        return [[0, 0], [2400, 0], [2400, 1200], [0, 1200]];
+    }
+
+    let polygon = (boardData.polygon && boardData.polygon.length ? boardData.polygon : defaultPolygon()).map(clonePoint);
+    let minX = 0;
+    let maxX = 0;
+    let minY = 0;
+    let maxY = 0;
+    let widthMm = 1;
+    let heightMm = 1;
+    let boardCenter = { x: 0, y: 0 };
+
+    function recalculateBoardGeometry() {
+        if (!polygon.length) {
+            polygon = defaultPolygon();
+        }
+        polygon = polygon.map(clonePoint);
+        const xs = polygon.map(pt => pt[0]);
+        const ys = polygon.map(pt => pt[1]);
+        minX = Math.min(...xs);
+        maxX = Math.max(...xs);
+        minY = Math.min(...ys);
+        maxY = Math.max(...ys);
+        widthMm = Math.max(maxX - minX, 1);
+        heightMm = Math.max(maxY - minY, 1);
+        boardCenter = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
+        boardData.polygon = polygon.map(pt => pt.slice());
+        boardData.orientation = boardOrientation;
+    }
+
+    recalculateBoardGeometry();
 
     function postToStreamlit(type, payload = {}) {
         if (window.Streamlit) {
@@ -332,34 +434,30 @@
     const zoomSlider = document.getElementById('zoomSlider');
     const zoomValueLabel = document.getElementById('zoomValue');
     const resetViewButton = document.getElementById('resetView');
+    const orientationLabel = document.getElementById('boardOrientationLabel');
+    const rotateBoardLeftButton = document.getElementById('boardRotateLeft');
+    const rotateBoardRightButton = document.getElementById('boardRotateRight');
 
-    const polygon = boardData.polygon && boardData.polygon.length ? boardData.polygon : [
-        [0, 0], [2400, 0], [2400, 1200], [0, 1200]
-    ];
-    const xs = polygon.map(pt => pt[0]);
-    const ys = polygon.map(pt => pt[1]);
-    const minX = Math.min(...xs);
-    const maxX = Math.max(...xs);
-    const minY = Math.min(...ys);
-    const maxY = Math.max(...ys);
-    const widthMm = Math.max(maxX - minX, 1);
-    const heightMm = Math.max(maxY - minY, 1);
-    const padding = 60;
-    const boardCenter = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 };
-    const guideCircles = initialCircles.map((circle, idx) => {
-        const radius = typeof circle.radius === 'number' ? circle.radius : 0;
-        if (!radius || radius <= 0) { return null; }
-        const x = typeof circle.x === 'number' ? circle.x : boardCenter.x;
-        const y = typeof circle.y === 'number' ? circle.y : boardCenter.y;
-        return {
-            id: circle.id || ('circle-' + idx),
-            radius,
-            x,
-            y,
-            color: typeof circle.color === 'string' && circle.color ? circle.color : colorPalette[nextCircleColor++ % colorPalette.length],
-            label: typeof circle.label === 'string' && circle.label ? circle.label : `Radius ${radius.toFixed(0)} mm`,
-        };
-    }).filter(Boolean);
+    function buildGuideCircleList(source) {
+        nextCircleColor = 0;
+        return (Array.isArray(source) ? source : []).map((circle, idx) => {
+            if (!circle || typeof circle !== 'object') { return null; }
+            const radius = typeof circle.radius === 'number' ? circle.radius : 0;
+            if (!radius || radius <= 0) { return null; }
+            const x = typeof circle.x === 'number' ? circle.x : boardCenter.x;
+            const y = typeof circle.y === 'number' ? circle.y : boardCenter.y;
+            return {
+                id: circle.id || ('circle-' + idx),
+                radius,
+                x,
+                y,
+                color: typeof circle.color === 'string' && circle.color ? circle.color : colorPalette[nextCircleColor++ % colorPalette.length],
+                label: typeof circle.label === 'string' && circle.label ? circle.label : `Radius ${radius.toFixed(0)} mm`,
+            };
+        }).filter(Boolean);
+    }
+
+    let guideCircles = buildGuideCircleList(initialCircles);
     let circleCounter = guideCircles.length;
     let selectedCircleId = guideCircles.length ? guideCircles[guideCircles.length - 1].id : null;
     let draggingCircleId = null;
@@ -367,6 +465,14 @@
     const SNAP_DISTANCE_MM = 200;
     const CONNECTION_TOLERANCE_MM = 3;
     const ANGLE_TOLERANCE_RAD = Math.PI / 36;
+
+    function updateBoardOrientationLabel() {
+        if (!orientationLabel) { return; }
+        const value = ((boardOrientation % 360) + 360) % 360;
+        orientationLabel.textContent = `${Math.round(value)}°`;
+    }
+
+    updateBoardOrientationLabel();
 
     function toRadians(degrees) {
         return (degrees || 0) * Math.PI / 180;
@@ -787,6 +893,35 @@
         return best;
     }
 
+    function rotateBoard(deltaDegrees) {
+        if (!Number.isFinite(deltaDegrees)) { return; }
+        const radians = toRadians(deltaDegrees);
+        const centre = { x: boardCenter.x, y: boardCenter.y };
+        polygon = polygon.map(point => {
+            const rotated = rotatePoint(point[0] - centre.x, point[1] - centre.y, radians);
+            return [centre.x + rotated.x, centre.y + rotated.y];
+        });
+        placements.forEach(piece => {
+            const rotated = rotatePoint(piece.x - centre.x, piece.y - centre.y, radians);
+            piece.x = centre.x + rotated.x;
+            piece.y = centre.y + rotated.y;
+            piece.rotation = (piece.rotation + deltaDegrees + 360) % 360;
+        });
+        guideCircles.forEach(circle => {
+            const rotated = rotatePoint(circle.x - centre.x, circle.y - centre.y, radians);
+            circle.x = centre.x + rotated.x;
+            circle.y = centre.y + rotated.y;
+        });
+        boardOrientation = (boardOrientation + deltaDegrees) % 360;
+        recalculateBoardGeometry();
+        clampPan();
+        draw();
+        updateBoardOrientationLabel();
+        updateSelectionLabel();
+        renderCircleList();
+        emitState();
+    }
+
     function emitState() {
         const payload = {
             placements: placements.map(item => ({
@@ -805,7 +940,11 @@
                 color: circle.color,
                 label: circle.label,
             })),
-            board: boardData,
+            board: {
+                description: boardData.description,
+                polygon: polygon.map(pt => pt.slice()),
+                orientation: boardOrientation,
+            },
             zoom,
         };
         postToStreamlit("streamlit:setComponentValue", {
@@ -824,15 +963,21 @@
         return colour;
     }
 
+    function currentFrameHeight() {
+        const bodyHeight = document.body ? document.body.scrollHeight : 0;
+        const docHeight = document.documentElement ? document.documentElement.scrollHeight : 0;
+        return Math.max(bodyHeight, docHeight, window.innerHeight || 0);
+    }
+
     function requestFrameHeight() {
         postToStreamlit("streamlit:setFrameHeight", {
-            height: document.body.scrollHeight,
+            height: currentFrameHeight(),
         });
     }
 
     function announceReady() {
         postToStreamlit("streamlit:componentReady", {
-            height: document.body.scrollHeight,
+            height: currentFrameHeight(),
         });
     }
 
@@ -854,6 +999,72 @@
         updateSelectionLabel();
         draw();
         emitState();
+    }
+
+    function applyBoardPayload(payload, options = {}) {
+        if (!payload || typeof payload !== 'object') { return; }
+        const { recenter = false, emit = false } = options;
+        if (typeof payload.description === 'string') {
+            boardData.description = payload.description;
+        }
+        if (Array.isArray(payload.polygon) && payload.polygon.length) {
+            polygon = payload.polygon.map(clonePoint);
+        } else if (!polygon.length) {
+            polygon = defaultPolygon();
+        }
+        if (typeof payload.orientation === 'number') {
+            boardOrientation = payload.orientation;
+        }
+        recalculateBoardGeometry();
+        if (recenter) {
+            pan = { x: 0, y: 0 };
+        }
+        clampPan();
+        draw();
+        updateBoardOrientationLabel();
+        if (emit) {
+            emitState();
+        }
+    }
+
+    function applyRenderArgs(args) {
+        if (!args || typeof args !== 'object') { return; }
+        if (Array.isArray(args.library)) {
+            trackLibrary = args.library;
+            libraryByCode = Object.fromEntries(trackLibrary.map(item => [item.code, item]));
+        }
+        if (args.board) {
+            applyBoardPayload(args.board);
+        } else {
+            recalculateBoardGeometry();
+        }
+        if (Array.isArray(args.placements)) {
+            placements = args.placements.map((item, idx) => ({
+                id: item.id || ('placement-' + idx),
+                code: item.code,
+                x: typeof item.x === 'number' ? item.x : 0,
+                y: typeof item.y === 'number' ? item.y : 0,
+                rotation: typeof item.rotation === 'number' ? item.rotation : 0,
+                flipped: Boolean(item.flipped),
+            }));
+            nextId = placements.length;
+        }
+        if (Array.isArray(args.circles)) {
+            guideCircles = buildGuideCircleList(args.circles);
+            circleCounter = guideCircles.length;
+            selectedCircleId = guideCircles.length ? guideCircles[guideCircles.length - 1].id : null;
+        }
+        if (typeof args.zoom === 'number') {
+            zoom = Math.min(Math.max(args.zoom, MIN_ZOOM), MAX_ZOOM);
+            updateZoomUI();
+        }
+        selectedId = placements.length ? placements[placements.length - 1].id : null;
+        clampPan();
+        draw();
+        updateBoardOrientationLabel();
+        updateSelectionLabel();
+        renderCircleList();
+        requestFrameHeight();
     }
 
     function updateSelectionLabel() {
@@ -915,6 +1126,13 @@
         resetViewButton.addEventListener('click', () => {
             resetView();
         });
+    }
+
+    if (rotateBoardLeftButton) {
+        rotateBoardLeftButton.addEventListener('click', () => rotateBoard(-90));
+    }
+    if (rotateBoardRightButton) {
+        rotateBoardRightButton.addEventListener('click', () => rotateBoard(90));
     }
 
     let dragging = false;
@@ -1286,6 +1504,19 @@
             link.click();
             document.body.removeChild(link);
             setTimeout(() => URL.revokeObjectURL(url), 1000);
+        });
+    }
+
+    if (window.Streamlit && window.Streamlit.events && window.Streamlit.RENDER_EVENT) {
+        window.Streamlit.events.addEventListener(window.Streamlit.RENDER_EVENT, event => {
+            const detail = event && event.detail ? event.detail : {};
+            applyRenderArgs(detail.args || {});
+        });
+    } else {
+        window.addEventListener('message', event => {
+            if (event && event.data && event.data.type === 'streamlit:render') {
+                applyRenderArgs(event.data.args || {});
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- prevent the embedded planner background from scrolling and add a dedicated board orientation control strip
- make the board outline respond to updates from Streamlit by reacting to render arguments and persisting orientation in session state
- rotate placements, guide circles and board metadata together when applying 90° board turns

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e02e2afa608324a48c50596bea84ae