### PR TITLE
Add sidebar container for planning circles

### DIFF
--- a/_layout_designer_component/index.html
+++ b/_layout_designer_component/index.html
@@ -360,6 +360,10 @@
             <h3>Track library and curve guides</h3>
             <p class="hint">Click "Add to board" to drop a piece. Curved pieces also offer a planning circle that you can drag on the board.</p>
             <div class="library-sections" id="librarySections"></div>
+            <div class="circle-panel">
+                <h4>Planning circles</h4>
+                <div id="circleList" class="circle-list"></div>
+            </div>
         </aside>
     </div>
     <script src="https://unpkg.com/streamlit-component-lib/dist/index.js"></script>


### PR DESCRIPTION
## Summary
- add the missing circle panel markup beneath the library sections
- provide a circle list container for renderCircleList to populate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2d26ce52083248a1712ebf48df815