### PR TITLE
Debounce state updates from layout designer component

### DIFF
--- a/_layout_designer_component/index.html
+++ b/_layout_designer_component/index.html
@@ -1149,8 +1149,11 @@
         emitState();
     }
 
-    function emitState() {
-        const payload = {
+    let emitScheduled = false;
+    let lastEmittedJson = null;
+
+    function buildStatePayload() {
+        return {
             placements: placements.map(item => ({
                 id: item.id,
                 code: item.code,
@@ -1166,10 +1169,34 @@
             },
             zoom,
         };
+    }
+
+    function flushStatePayload() {
+        const payload = buildStatePayload();
+        const jsonValue = JSON.stringify(payload);
+        if (jsonValue === lastEmittedJson) {
+            return payload;
+        }
+        lastEmittedJson = jsonValue;
         postToStreamlit("streamlit:setComponentValue", {
-            value: JSON.stringify(payload),
+            value: jsonValue,
         });
         return payload;
+    }
+
+    function emitState(options = {}) {
+        const { immediate = false } = options;
+        if (immediate) {
+            return flushStatePayload();
+        }
+        if (!emitScheduled) {
+            emitScheduled = true;
+            requestAnimationFrame(() => {
+                emitScheduled = false;
+                flushStatePayload();
+            });
+        }
+        return buildStatePayload();
     }
 
     function getCircleById(id) {
@@ -1709,7 +1736,7 @@
     const saveLayoutButton = document.getElementById('saveLayout');
     if (saveLayoutButton) {
         saveLayoutButton.addEventListener('click', () => {
-            const payload = emitState();
+            const payload = emitState({ immediate: true });
             const jsonText = JSON.stringify(payload, null, 2);
             const blob = new Blob([jsonText], { type: 'application/json' });
             const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- debounce calls from the custom layout designer to Streamlit so repeated UI updates do not cause constant rerenders
- cache the last emitted payload and skip resending unchanged state
- ensure the manual export button still emits immediately so saved files capture the latest layout

## Testing
- streamlit run app.py --server.port 8501 --server.headless true

------
https://chatgpt.com/codex/tasks/task_e_68e421da5c94832497c99a038d614682