### PR TITLE
Persist layout designer viewport pan state

### DIFF
--- a/_layout_designer_component/index.html
+++ b/_layout_designer_component/index.html
@@ -1168,6 +1168,10 @@
                 orientation: boardOrientation,
             },
             zoom,
+            pan: {
+                x: Number.isFinite(pan.x) ? pan.x : 0,
+                y: Number.isFinite(pan.y) ? pan.y : 0,
+            },
         };
     }
 
@@ -1296,6 +1300,14 @@
         if (typeof args.zoom === 'number') {
             zoom = Math.min(Math.max(args.zoom, MIN_ZOOM), MAX_ZOOM);
             updateZoomUI();
+        }
+        if (args.pan && typeof args.pan === 'object') {
+            const panX = Number(args.pan.x);
+            const panY = Number(args.pan.y);
+            if (Number.isFinite(panX) && Number.isFinite(panY)) {
+                pan.x = panX;
+                pan.y = panY;
+            }
         }
         let resolvedSelectedId = null;
         if (previousSelectedId && placements.some(item => item.id === previousSelectedId)) {
@@ -1545,6 +1557,7 @@
             pan.y -= event.deltaY;
             clampPan();
             draw();
+            emitState();
         }
     }, { passive: false });
 


### PR DESCRIPTION
## Summary
- persist the layout designer pan offset through component rerenders by round-tripping it through Streamlit
- add viewport pan data to saved and loaded layout JSON payloads
- emit state changes after wheel panning so previously placed track stays anchored when adding new pieces

## Testing
- `python -m compileall app.py planner.py`


------
https://chatgpt.com/codex/tasks/task_e_68e52b493b2c8333bd04f4077562e89c