### PR TITLE
Disable Streamlit overlay and improve snap behaviour

### DIFF
--- a/_layout_designer_component/index.html
+++ b/_layout_designer_component/index.html
@@ -649,7 +649,11 @@
     selectedCircleId = guideCircles.length ? guideCircles[guideCircles.length - 1].id : null;
     let draggingCircleId = null;
     let circleDragOffset = { x: 0, y: 0 };
-    const SNAP_DISTANCE_MM = 200;
+    // Allow snapping to consider every piece on the board. Previously this was limited to
+    // a small radius which meant the "Snap to piece" action did nothing unless the pieces
+    // were already close together. Lifting the radius ensures we always snap to the best
+    // available connection when the user explicitly requests it.
+    const SNAP_DISTANCE_MM = Number.POSITIVE_INFINITY;
     const CONNECTION_TOLERANCE_MM = 3;
     const ANGLE_TOLERANCE_RAD = Math.PI / 36;
 

--- a/app.py
+++ b/app.py
@@ -28,6 +28,16 @@ _layout_designer_component = components.declare_component(
 
 
 st.set_page_config(page_title="Hornby OO Layout Planner", layout="wide")
+st.markdown(
+    """
+    <style>
+    [data-testid="stStatusWidget"] {
+        display: none !important;
+    }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 st.title("Hornby OO Gauge Layout Planner")
 st.write(
     """Lay out your own Hornby OO gauge plan directly on the baseboard outline.\n"


### PR DESCRIPTION
## Summary
- hide Streamlit's status overlay so layout edits no longer darken the page
- expand the snap-to-piece search radius so pieces snap even when far apart

## Testing
- streamlit run app.py --server.port 8501 --server.headless true


------
https://chatgpt.com/codex/tasks/task_e_68e57acafe5483338725634c15bedc56